### PR TITLE
:beetle: Fix two small GL bugs

### DIFF
--- a/src/cs-graphics/LuminanceMipMap.cpp
+++ b/src/cs-graphics/LuminanceMipMap.cpp
@@ -107,6 +107,7 @@ LuminanceMipMap::LuminanceMipMap(int hdrBufferWidth, int hdrBufferHeight)
   glGenBuffers(1, &mPBO);
   glBindBuffer(GL_PIXEL_PACK_BUFFER, mPBO);
   glBufferStorage(GL_PIXEL_PACK_BUFFER, sizeof(float) * 2, nullptr, GL_MAP_READ_BIT);
+  glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
 
   mDataAvailable = false;
 

--- a/src/cs-graphics/internal/pbr_fragment_shader.hpp
+++ b/src/cs-graphics/internal/pbr_fragment_shader.hpp
@@ -33,7 +33,7 @@ out vec4 FragColor;
 
 uniform vec3 u_LightDirection;
 uniform vec3 u_LightColor;
-uniform vec3 u_EnableHDR;
+uniform bool u_EnableHDR;
 
 #ifdef USE_IBL
 uniform samplerCube u_DiffuseEnvSampler;


### PR DESCRIPTION
Unbind pbo after usage in LuminanceMipMap constructor and fix type of a uniform variable in the gltf fragment shader.