### PR TITLE
Feature/actions cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,13 +140,12 @@ jobs:
         run: |
           pip install clcache
           clcache -M 104857600
-          where.exe clcache
       - name: Build Externals
         shell: cmd
-        run: make_externals.bat -G "Visual Studio 15 Win64" -DCMAKE_VS_GLOBALS="CLToolExe=clcache.exe;TrackFileAccess=false"
+        run: make_externals.bat -G "Visual Studio 15 Win64" -DCMAKE_VS_GLOBALS=CLToolExe=clcache.exe;TrackFileAccess=false
       - name: Build CosmoScout VR
         shell: cmd
-        run: make.bat -G "Visual Studio 15 Win64" -DCMAKE_VS_GLOBALS="CLToolExe=clcache.exe;TrackFileAccess=false"
+        run: make.bat -G "Visual Studio 15 Win64" -DCMAKE_VS_GLOBALS=CLToolExe=clcache.exe;TrackFileAccess=false
       - name: Run Tests
         shell: cmd
         run: install\\windows-release\\bin\\run_all_tests.bat

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Cache Object Files
         uses: actions/cache@v1
         with:
-          path: ~/.ccache
+          path: $HOME/.ccache
           key: linux-gcc
       - name: Install CMake
         run: sudo pip install cmake
@@ -86,7 +86,7 @@ jobs:
       - name: Cache Object Files
         uses: actions/cache@v1
         with:
-          path: ~/.ccache
+          path: $HOME/.ccache
           key: linux-clang
       - name: Install CMake
         run: sudo pip install cmake
@@ -125,7 +125,7 @@ jobs:
       - name: Cache Object Files
         uses: actions/cache@v1
         with:
-          path: %HOME%\\clcache
+          path: ${{ env.HOME }}\\clcache
           key: windows-msvc
       - name: Build Externals
         shell: cmd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,13 +140,13 @@ jobs:
         run: |
           pip install clcache
           clcache -M 104857600
-          where clcache
+          where.exe clcache
       - name: Build Externals
         shell: cmd
-        run: make_externals.bat -G "Visual Studio 15 Win64" -DCMAKE_CXX_COMPILER=clcache -DCMAKE_C_COMPILER=clcache
+        run: make_externals.bat -G "Visual Studio 15 Win64" -DCMAKE_VS_GLOBALS="CLToolExe=clcache.exe;CLToolPath=C:\Python37\Scripts;TrackFileAccess=false"
       - name: Build CosmoScout VR
         shell: cmd
-        run: make.bat -G "Visual Studio 15 Win64" -DCMAKE_CXX_COMPILER=clcache -DCMAKE_C_COMPILER=clcache
+        run: make.bat -G "Visual Studio 15 Win64" -DCMAKE_VS_GLOBALS="CLToolExe=clcache.exe;CLToolPath=C:\Python37\Scripts;TrackFileAccess=false"
       - name: Run Tests
         shell: cmd
         run: install\\windows-release\\bin\\run_all_tests.bat

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,10 +55,9 @@ jobs:
           sudo add-apt-repository ppa:mhier/libboost-latest
           sudo apt-get update -q
           sudo apt-get install libc++-dev libgl1-mesa-dev libglu1-mesa-dev libx11-dev
-          sudo apt-get install libxi-dev libgconf-2-4 libboost1.70-dev ccache
-          sudo apt-get install -y lcov
+          sudo apt-get install libxi-dev libgconf-2-4 libboost1.70-dev ccache lcov
           sudo pip install cmake
-          ccache --max-size 100M
+          ccache --max-size 1G
       - name: Build Externals
         run: ./make_externals.sh -G "Unix Makefiles" -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
       - name: Build CosmoScout VR
@@ -101,7 +100,7 @@ jobs:
           sudo apt-get install libc++-dev libgl1-mesa-dev libglu1-mesa-dev libx11-dev
           sudo apt-get install libxi-dev libgconf-2-4 libboost1.70-dev ccache
           sudo pip install cmake
-          ccache --max-size 100M
+          ccache --max-size 1G
       - name: Build Externals
         env:
           CC: clang
@@ -139,7 +138,6 @@ jobs:
       - name: Download Dependencies
         run: |
           pip install clcache
-          clcache -M 104857600
       - name: Build Externals
         shell: cmd
         run: make_externals.bat -G "Visual Studio 15 Win64" -DCMAKE_VS_GLOBALS=CLToolExe=clcache.exe;TrackFileAccess=false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,9 +60,9 @@ jobs:
           sudo pip install cmake
           ccache --max-size 100M
       - name: Build Externals
-        run: ./make_externals.sh -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
+        run: ./make_externals.sh -G "Unix Makefiles" -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
       - name: Build CosmoScout VR
-        run: ./make.sh -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
+        run: ./make.sh -G "Unix Makefiles" -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
       - name: Run Tests
         run: ./install/linux-release/bin/run_all_tests.sh
       - name: Calculate Test Coverage
@@ -106,12 +106,12 @@ jobs:
         env:
           CC: clang
           CXX: clang++
-        run: ./make_externals.sh -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
+        run: ./make_externals.sh -G "Unix Makefiles" -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
       - name: Build CosmoScout VR
         env:
           CC: clang
           CXX: clang++
-        run: ./make.sh -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
+        run: ./make.sh -G "Unix Makefiles" -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
       - name: Run Tests
         run: ./install/linux-release/bin/run_all_tests.sh
 
@@ -140,12 +140,13 @@ jobs:
         run: |
           pip install clcache
           clcache -M 104857600
+          where clcache
       - name: Build Externals
         shell: cmd
-        run: make_externals.bat -DCMAKE_CXX_COMPILER=clcache -DCMAKE_C_COMPILER=clcache
+        run: make_externals.bat -G "Visual Studio 15 Win64" -DCMAKE_CXX_COMPILER=clcache -DCMAKE_C_COMPILER=clcache
       - name: Build CosmoScout VR
         shell: cmd
-        run: make.bat -DCMAKE_CXX_COMPILER=clcache -DCMAKE_C_COMPILER=clcache
+        run: make.bat -G "Visual Studio 15 Win64" -DCMAKE_CXX_COMPILER=clcache -DCMAKE_C_COMPILER=clcache
       - name: Run Tests
         shell: cmd
         run: install\\windows-release\\bin\\run_all_tests.bat

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,8 +136,7 @@ jobs:
             msvc-${{ github.ref }}-
             msvc-
       - name: Download Dependencies
-        run: |
-          pip install clcache
+        run: pip install clcache
       - name: Build Externals
         shell: cmd
         run: make_externals.bat -G "Visual Studio 15 Win64" -DCMAKE_VS_GLOBALS=CLToolExe=clcache.exe;TrackFileAccess=false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,7 +144,7 @@ jobs:
       - name: Download Dependencies
         run: |
           pip install clcache
-          clcache -M 5368709120
+          clcache -M 2147483648
           clcache -z
       - name: Build Externals
         shell: cmd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,10 +143,10 @@ jobs:
           where.exe clcache
       - name: Build Externals
         shell: cmd
-        run: make_externals.bat -G "Visual Studio 15 Win64" -DCMAKE_VS_GLOBALS="CLToolExe=clcache.exe;CLToolPath=C:\Python37\Scripts;TrackFileAccess=false"
+        run: make_externals.bat -G "Visual Studio 15 Win64" -DCMAKE_VS_GLOBALS="CLToolExe=clcache.exe;TrackFileAccess=false"
       - name: Build CosmoScout VR
         shell: cmd
-        run: make.bat -G "Visual Studio 15 Win64" -DCMAKE_VS_GLOBALS="CLToolExe=clcache.exe;CLToolPath=C:\Python37\Scripts;TrackFileAccess=false"
+        run: make.bat -G "Visual Studio 15 Win64" -DCMAKE_VS_GLOBALS="CLToolExe=clcache.exe;TrackFileAccess=false"
       - name: Run Tests
         shell: cmd
         run: install\\windows-release\\bin\\run_all_tests.bat

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,10 +45,8 @@ jobs:
       - name: Cache Object Files
         uses: actions/cache@v1
         with:
-          path: ${{ env.HOME }}/.ccache
+          path: ${HOME}/.ccache
           key: linux-gcc
-      - name: Install CMake
-        run: sudo pip install cmake
       - name: Download Dependencies
         run: |
           sudo add-apt-repository ppa:mhier/libboost-latest
@@ -56,6 +54,7 @@ jobs:
           sudo apt-get install libc++-dev libgl1-mesa-dev libglu1-mesa-dev libx11-dev
           sudo apt-get install libxi-dev libgconf-2-4 libboost1.70-dev ccache
           sudo apt-get install -y lcov
+          sudo pip install cmake
       - name: Build Externals
         run: ./make_externals.sh -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
       - name: Build CosmoScout VR
@@ -86,16 +85,15 @@ jobs:
       - name: Cache Object Files
         uses: actions/cache@v1
         with:
-          path: ${{ env.HOME }}/.ccache
+          path: ${HOME}/.ccache
           key: linux-clang
-      - name: Install CMake
-        run: sudo pip install cmake
       - name: Download Dependencies
         run: |
           sudo add-apt-repository ppa:mhier/libboost-latest
           sudo apt-get update -q
           sudo apt-get install libc++-dev libgl1-mesa-dev libglu1-mesa-dev libx11-dev
           sudo apt-get install libxi-dev libgconf-2-4 libboost1.70-dev ccache
+          sudo pip install cmake
       - name: Build Externals
         env:
           CC: clang
@@ -125,14 +123,22 @@ jobs:
       - name: Cache Object Files
         uses: actions/cache@v1
         with:
-          path: ${{ env.HOME }}\\clcache
+          path: ${HOME}\\clcache
           key: windows-msvc
+      - name: Download Dependencies
+        run: pip install clcache
       - name: Build Externals
         shell: cmd
-        run: make_externals.bat -DCMAKE_CXX_COMPILER_LAUNCHER=clcache -DCMAKE_C_COMPILER_LAUNCHER=clcache
+        env:
+          CC: clcache
+          CXX: clcache
+        run: make_externals.bat
       - name: Build CosmoScout VR
         shell: cmd
-        run: make.bat -DCMAKE_CXX_COMPILER_LAUNCHER=clcache -DCMAKE_C_COMPILER_LAUNCHER=clcache
+        env:
+          CC: clcache
+          CXX: clcache
+        run: make.bat
       - name: Run Tests
         shell: cmd
         run: install\\windows-release\\bin\\run_all_tests.bat

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,10 +136,16 @@ jobs:
             msvc-${{ github.ref }}-
             msvc-
       - name: Download Dependencies
-        run: pip install clcache
+        run: |
+          pip install clcache
+          clcache -s
+          clcache -z
+          clcache -M 1073741824
       - name: Build Externals
         shell: cmd
-        run: make_externals.bat -G "Visual Studio 15 Win64" -DCMAKE_VS_GLOBALS=CLToolExe=clcache.exe;TrackFileAccess=false
+        run: |
+          make_externals.bat -G "Visual Studio 15 Win64" -DCMAKE_VS_GLOBALS=CLToolExe=clcache.exe;TrackFileAccess=false
+          clcache -s
       - name: Build CosmoScout VR
         shell: cmd
         run: make.bat -G "Visual Studio 15 Win64" -DCMAKE_VS_GLOBALS=CLToolExe=clcache.exe;TrackFileAccess=false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,12 +58,15 @@ jobs:
           sudo apt-get install libxi-dev libgconf-2-4 libboost1.70-dev ccache lcov
           sudo pip install cmake
           ccache --max-size 1G
+          ccache -z
       - name: Build Externals
         run: ./make_externals.sh -G "Unix Makefiles" -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
       - name: Build CosmoScout VR
         run: ./make.sh -G "Unix Makefiles" -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
       - name: Run Tests
         run: ./install/linux-release/bin/run_all_tests.sh
+      - name: Print Cache Usage
+        run: ccache -s
       - name: Calculate Test Coverage
         run: ./lcov.sh
       - name: Upload Coverage Info
@@ -101,6 +104,7 @@ jobs:
           sudo apt-get install libxi-dev libgconf-2-4 libboost1.70-dev ccache
           sudo pip install cmake
           ccache --max-size 1G
+          ccache -z
       - name: Build Externals
         env:
           CC: clang
@@ -113,6 +117,8 @@ jobs:
         run: ./make.sh -G "Unix Makefiles" -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
       - name: Run Tests
         run: ./install/linux-release/bin/run_all_tests.sh
+      - name: Print Cache Usage
+        run: ccache -s
 
   build_windows:
     name: Windows MSVC 19.16.27032.1
@@ -138,17 +144,16 @@ jobs:
       - name: Download Dependencies
         run: |
           pip install clcache
-          clcache -s
+          clcache -M 5368709120
           clcache -z
-          clcache -M 1073741824
       - name: Build Externals
         shell: cmd
-        run: |
-          make_externals.bat -G "Visual Studio 15 Win64" -DCMAKE_VS_GLOBALS=CLToolExe=clcache.exe;TrackFileAccess=false
-          clcache -s
+        run: make_externals.bat -G "Visual Studio 15 Win64" -DCMAKE_VS_GLOBALS=CLToolExe=clcache.exe;TrackFileAccess=false
       - name: Build CosmoScout VR
         shell: cmd
         run: make.bat -G "Visual Studio 15 Win64" -DCMAKE_VS_GLOBALS=CLToolExe=clcache.exe;TrackFileAccess=false
       - name: Run Tests
         shell: cmd
         run: install\\windows-release\\bin\\run_all_tests.bat
+      - name: Print Cache Usage
+        run: clcache -s

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,10 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.ccache
-          key: linux-gcc
+          key: gcc-${{ github.ref }}-${{ github.sha }}
+          restore-keys: |
+            gcc-${{ github.ref }}-
+            gcc-
       - name: Download Dependencies
         run: |
           sudo add-apt-repository ppa:mhier/libboost-latest
@@ -55,6 +58,7 @@ jobs:
           sudo apt-get install libxi-dev libgconf-2-4 libboost1.70-dev ccache
           sudo apt-get install -y lcov
           sudo pip install cmake
+          ccache --max-size 100M
       - name: Build Externals
         run: ./make_externals.sh -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
       - name: Build CosmoScout VR
@@ -86,7 +90,10 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.ccache
-          key: linux-clang
+          key: clang-${{ github.ref }}-${{ github.sha }}
+          restore-keys: |
+            clang-${{ github.ref }}-
+            clang-
       - name: Download Dependencies
         run: |
           sudo add-apt-repository ppa:mhier/libboost-latest
@@ -94,6 +101,7 @@ jobs:
           sudo apt-get install libc++-dev libgl1-mesa-dev libglu1-mesa-dev libx11-dev
           sudo apt-get install libxi-dev libgconf-2-4 libboost1.70-dev ccache
           sudo pip install cmake
+          ccache --max-size 100M
       - name: Build Externals
         env:
           CC: clang
@@ -124,9 +132,14 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/clcache
-          key: windows-msvc
+          key: msvc-${{ github.ref }}-${{ github.sha }}
+          restore-keys: |
+            msvc-${{ github.ref }}-
+            msvc-
       - name: Download Dependencies
-        run: pip install clcache
+        run: |
+          pip install clcache
+          clcache -M 104857600
       - name: Build Externals
         shell: cmd
         run: make_externals.bat -DCMAKE_CXX_COMPILER=clcache -DCMAKE_C_COMPILER=clcache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,11 @@ jobs:
         uses: actions/checkout@v1
       - name: Checkout Submodules
         run: git submodule update --init
+      - name: Cache Object Files
+        uses: actions/cache@v1
+        with:
+          path: ~/.ccache
+          key: linux-gcc
       - name: Install CMake
         run: sudo pip install cmake
       - name: Download Dependencies
@@ -49,12 +54,12 @@ jobs:
           sudo add-apt-repository ppa:mhier/libboost-latest
           sudo apt-get update -q
           sudo apt-get install libc++-dev libgl1-mesa-dev libglu1-mesa-dev libx11-dev
-          sudo apt-get install libxi-dev libgconf-2-4 libboost1.70-dev
+          sudo apt-get install libxi-dev libgconf-2-4 libboost1.70-dev ccache
           sudo apt-get install -y lcov
       - name: Build Externals
-        run: ./make_externals.sh
+        run: ./make_externals.sh -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
       - name: Build CosmoScout VR
-        run: ./make.sh
+        run: ./make.sh -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
       - name: Run Tests
         run: ./install/linux-release/bin/run_all_tests.sh
       - name: Calculate Test Coverage
@@ -78,6 +83,11 @@ jobs:
         uses: actions/checkout@v1
       - name: Checkout Submodules
         run: git submodule update --init
+      - name: Cache Object Files
+        uses: actions/cache@v1
+        with:
+          path: ~/.ccache
+          key: linux-clang
       - name: Install CMake
         run: sudo pip install cmake
       - name: Download Dependencies
@@ -85,17 +95,17 @@ jobs:
           sudo add-apt-repository ppa:mhier/libboost-latest
           sudo apt-get update -q
           sudo apt-get install libc++-dev libgl1-mesa-dev libglu1-mesa-dev libx11-dev
-          sudo apt-get install libxi-dev libgconf-2-4 libboost1.70-dev
+          sudo apt-get install libxi-dev libgconf-2-4 libboost1.70-dev ccache
       - name: Build Externals
         env:
           CC: clang
           CXX: clang++
-        run: ./make_externals.sh
+        run: ./make_externals.sh -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
       - name: Build CosmoScout VR
         env:
           CC: clang
           CXX: clang++
-        run: ./make.sh
+        run: ./make.sh -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
       - name: Run Tests
         run: ./install/linux-release/bin/run_all_tests.sh
 
@@ -112,12 +122,17 @@ jobs:
         uses: actions/checkout@v1
       - name: Checkout Submodules
         run: git submodule update --init
+      - name: Cache Object Files
+        uses: actions/cache@v1
+        with:
+          path: %HOME%\\clcache
+          key: windows-msvc
       - name: Build Externals
         shell: cmd
-        run: make_externals.bat
+        run: make_externals.bat -DCMAKE_CXX_COMPILER_LAUNCHER=clcache -DCMAKE_C_COMPILER_LAUNCHER=clcache
       - name: Build CosmoScout VR
         shell: cmd
-        run: make.bat
+        run: make.bat -DCMAKE_CXX_COMPILER_LAUNCHER=clcache -DCMAKE_C_COMPILER_LAUNCHER=clcache
       - name: Run Tests
         shell: cmd
         run: install\\windows-release\\bin\\run_all_tests.bat

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Cache Object Files
         uses: actions/cache@v1
         with:
-          path: $HOME/.ccache
+          path: ${{ env.HOME }}/.ccache
           key: linux-gcc
       - name: Install CMake
         run: sudo pip install cmake
@@ -86,7 +86,7 @@ jobs:
       - name: Cache Object Files
         uses: actions/cache@v1
         with:
-          path: $HOME/.ccache
+          path: ${{ env.HOME }}/.ccache
           key: linux-clang
       - name: Install CMake
         run: sudo pip install cmake

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
           if [ ! -z "$DIFF" ]; then echo $DIFF && exit 1; fi
 
   build_linux_gcc:
-    name: Linux Build (gcc 7.4.0)
+    name: Linux GCC 7.4.0
     runs-on: ubuntu-18.04
     if: >
       github.event_name == 'pull_request' ||
@@ -70,7 +70,7 @@ jobs:
           path-to-lcov: ./build/linux-release/coverage.info
 
   build_linux_clang:
-    name: Linux Build (clang 6.0)
+    name: Linux Clang 6.0
     runs-on: ubuntu-18.04
     if: >
       github.event_name == 'pull_request' ||
@@ -108,7 +108,7 @@ jobs:
         run: ./install/linux-release/bin/run_all_tests.sh
 
   build_windows:
-    name: Windows Build (msvc 19.16.27032.1)
+    name: Windows MSVC 19.16.27032.1
     runs-on: windows-2016
     if: >
       github.event_name == 'pull_request' ||
@@ -129,16 +129,10 @@ jobs:
         run: pip install clcache
       - name: Build Externals
         shell: cmd
-        env:
-          CC: clcache
-          CXX: clcache
-        run: make_externals.bat
+        run: make_externals.bat -DCMAKE_CXX_COMPILER=clcache -DCMAKE_C_COMPILER=clcache
       - name: Build CosmoScout VR
         shell: cmd
-        env:
-          CC: clcache
-          CXX: clcache
-        run: make.bat
+        run: make.bat -DCMAKE_CXX_COMPILER=clcache -DCMAKE_C_COMPILER=clcache
       - name: Run Tests
         shell: cmd
         run: install\\windows-release\\bin\\run_all_tests.bat

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Cache Object Files
         uses: actions/cache@v1
         with:
-          path: ${HOME}/.ccache
+          path: ~/.ccache
           key: linux-gcc
       - name: Download Dependencies
         run: |
@@ -85,7 +85,7 @@ jobs:
       - name: Cache Object Files
         uses: actions/cache@v1
         with:
-          path: ${HOME}/.ccache
+          path: ~/.ccache
           key: linux-clang
       - name: Download Dependencies
         run: |
@@ -123,7 +123,7 @@ jobs:
       - name: Cache Object Files
         uses: actions/cache@v1
         with:
-          path: ${HOME}\\clcache
+          path: ~/clcache
           key: windows-msvc
       - name: Download Dependencies
         run: pip install clcache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,10 +148,10 @@ jobs:
           clcache -z
       - name: Build Externals
         shell: cmd
-        run: make_externals.bat -G "Visual Studio 15 Win64" -DCMAKE_VS_GLOBALS=CLToolExe=clcache.exe;TrackFileAccess=false
+        run: make_externals.bat -G "Visual Studio 15 Win64" -DCMAKE_VS_GLOBALS="CLToolExe=clcache.exe;TrackFileAccess=false"
       - name: Build CosmoScout VR
         shell: cmd
-        run: make.bat -G "Visual Studio 15 Win64" -DCMAKE_VS_GLOBALS=CLToolExe=clcache.exe;TrackFileAccess=false
+        run: make.bat -G "Visual Studio 15 Win64" -DCMAKE_VS_GLOBALS="CLToolExe=clcache.exe;TrackFileAccess=false"
       - name: Run Tests
         shell: cmd
         run: install\\windows-release\\bin\\run_all_tests.bat

--- a/docs/ide-setup.md
+++ b/docs/ide-setup.md
@@ -336,6 +336,10 @@ If you are on Windows, you may have to replace the `"BOOST_ROOT"` environment va
 
 With this file in place, you can press `Ctrl+Shift+P` and select `Tasks: Run Task`. Now you can first select `Make Externals (Release)`, then `Make (Release)` and later `Run CosmoScout VR`.
 
+:information_source: _**Tip (Linux only):** You can use [ccache](https://ccache.dev/) to considerably speed up build times. You just need to replace the commands with `./make_externals.sh -G "Unix Makefiles" -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache` and `./make.sh -G "Unix Makefiles" -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache` respectively._
+
+:information_source: _**Tip (Windows only):** You can use [clcache](https://github.com/frerich/clcache) to considerably speed up build times. You just need to call `make_externals.bat -G "Visual Studio 15 Win64" -DCMAKE_VS_GLOBALS=CLToolExe=clcache.exe;TrackFileAccess=false` and `make.bat -G "Visual Studio 15 Win64" -DCMAKE_VS_GLOBALS="CLToolExe=clcache.exe;TrackFileAccess=false"` respectively._
+
 ### `.vscode/c_cpp_properties.json`
 
 ```json

--- a/docs/ide-setup.md
+++ b/docs/ide-setup.md
@@ -338,7 +338,7 @@ With this file in place, you can press `Ctrl+Shift+P` and select `Tasks: Run Tas
 
 :information_source: _**Tip (Linux only):** You can use [ccache](https://ccache.dev/) to considerably speed up build times. You just need to replace the commands with `./make_externals.sh -G "Unix Makefiles" -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache` and `./make.sh -G "Unix Makefiles" -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache` respectively._
 
-:information_source: _**Tip (Windows only):** You can use [clcache](https://github.com/frerich/clcache) to considerably speed up build times. You just need to call `make_externals.bat -G "Visual Studio 15 Win64" -DCMAKE_VS_GLOBALS=CLToolExe=clcache.exe;TrackFileAccess=false` and `make.bat -G "Visual Studio 15 Win64" -DCMAKE_VS_GLOBALS="CLToolExe=clcache.exe;TrackFileAccess=false"` respectively._
+:information_source: _**Tip (Windows only):** You can use [clcache](https://github.com/frerich/clcache) to considerably speed up build times. You just need to call `make_externals.bat -G "Visual Studio 15 Win64" -DCMAKE_VS_GLOBALS=CLToolExe="clcache.exe;TrackFileAccess=false"` and `make.bat -G "Visual Studio 15 Win64" -DCMAKE_VS_GLOBALS="CLToolExe=clcache.exe;TrackFileAccess=false"` respectively._
 
 ### `.vscode/c_cpp_properties.json`
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -2,12 +2,12 @@
   <img src ="img/banner-earth.jpg" />
 </p>
 
-# Build Instructions
+# Generic Build Instructions
 
-:warning: _**Warning:** The [default configuration](../config/base/scene/simple_desktop.json) only contains a few data sets with very low resolution. Please read the [Configuring Guide](configuring.md) and the documentation of the [individual plugins](../README.md#Plugins-for-CosmoScout-VR) for including new data sets._
+:information_source: _**Tip:** This page contains generic build instructions for CosmoScout VR. Alternatively, you can follow a [guide specific to your IDE](ide-setup.md)._
 
 **CosmoScout VR supports 64 bits only and can be build in debug and release mode on Linux and Windows.
-You will need a copy of [CMake](https://cmake.org/) (version 3.12 or greater), [Boost](https://www.boost.org/) (version 1.69 or greater) and a recent C++ compiler (gcc 7, clang 5 or msvc 19).
+You will need a copy of [CMake](https://cmake.org/) (version 3.13 or greater), [Boost](https://www.boost.org/) (version 1.69 or greater) and a recent C++ compiler (gcc 7, clang 5 or msvc 19).
 For the compilation of the externals [Python](https://www.python.org/) is also required.**
 
 When compiling from source, you can either choose the `master` branch which contains the code of the last stable release or you can switch to the `develop` branch to test the latest features.
@@ -67,6 +67,8 @@ The progress of this operation is shown on the loading screen.
 
 For **manual compilation** follow the steps outlined in [make.sh](../make.sh).
 
+:information_source: _**Tip:** You can use [ccache](https://ccache.dev/) to considerably speed up build times. You just need to call `./make_externals.sh -G "Unix Makefiles" -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache` and `./make.sh -G "Unix Makefiles" -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache` respectively._
+
 ## Windows
 
 :warning: _**Warning:** During compilation of the externals, files with pretty long names are generated. Since Windows does not support paths longer 260 letters, you have to compile CosmoScout VR quite close to your file system root (`e.g. C:\cosmoscout-vr`). If you are on Windows 10, [you can disable this limit](https://www.howtogeek.com/266621/how-to-make-windows-10-accept-file-paths-over-260-characters/)._
@@ -120,6 +122,8 @@ When started for the very first time, some example datasets will be downloaded f
 The progress of this operation is shown on the loading screen.
 
 :information_source: _**Tip:** If you wish, you can delete the directories `build` and `install` at any time in order to force a complete reconfiguration or re-installation._
+
+:information_source: _**Tip:** You can use [clcache](https://github.com/frerich/clcache) to considerably speed up build times. You just need to call `make_externals.bat -G "Visual Studio 15 Win64" -DCMAKE_VS_GLOBALS=CLToolExe=clcache.exe;TrackFileAccess=false` and `make.bat -G "Visual Studio 15 Win64" -DCMAKE_VS_GLOBALS=CLToolExe=clcache.exe;TrackFileAccess=false` respectively._
 
 <p align="center">
   <a href="README.md">&#8962; Help Index</a>

--- a/docs/install.md
+++ b/docs/install.md
@@ -123,7 +123,7 @@ The progress of this operation is shown on the loading screen.
 
 :information_source: _**Tip:** If you wish, you can delete the directories `build` and `install` at any time in order to force a complete reconfiguration or re-installation._
 
-:information_source: _**Tip:** You can use [clcache](https://github.com/frerich/clcache) to considerably speed up build times. You just need to call `make_externals.bat -G "Visual Studio 15 Win64" -DCMAKE_VS_GLOBALS=CLToolExe=clcache.exe;TrackFileAccess=false` and `make.bat -G "Visual Studio 15 Win64" -DCMAKE_VS_GLOBALS=CLToolExe=clcache.exe;TrackFileAccess=false` respectively._
+:information_source: _**Tip:** You can use [clcache](https://github.com/frerich/clcache) to considerably speed up build times. You just need to call `make_externals.bat -G "Visual Studio 15 Win64" -DCMAKE_VS_GLOBALS="CLToolExe=clcache.exe;TrackFileAccess=false"` and `make.bat -G "Visual Studio 15 Win64" -DCMAKE_VS_GLOBALS=CLToolExe"=clcache.exe;TrackFileAccess=false"` respectively._
 
 <p align="center">
   <a href="README.md">&#8962; Help Index</a>

--- a/docs/using.md
+++ b/docs/using.md
@@ -6,6 +6,8 @@
 
 :construction: _**Under Construction:** This guide is still far from complete. We will improve it in the future._
 
+:warning: _**Warning:** The [default configuration](../config/base/scene/simple_desktop.json) only contains a few data sets with very low resolution. Please read the [Configuring Guide](configuring.md) and the documentation of the [individual plugins](../README.md#Plugins-for-CosmoScout-VR) for including new data sets._
+
 **Navigation:** There are several ways for interacting with the scene.
 Currently mouse, keyboard and space navigator are supported.
 More input devices can be added via VRPN.

--- a/make_externals.bat
+++ b/make_externals.bat
@@ -272,7 +272,7 @@ rmdir %CEF_DIR%\tests /s /q
 cd ..
 
 cmake %CMAKE_FLAGS% -DCMAKE_INSTALL_PREFIX="%INSTALL_DIR%"^
-      -DCEF_RUNTIME_LIBRARY_FLAG=/MD^
+      -DCEF_RUNTIME_LIBRARY_FLAG=/MD -DCEF_DEBUG_INFO_FLAG=""^
       "%BUILD_DIR%/cef/extracted/%CEF_DIR%" || exit /b
 
 cmake --build . --config %BUILD_TYPE% --parallel 8 || exit /b

--- a/make_externals.bat
+++ b/make_externals.bat
@@ -77,8 +77,8 @@ echo Building and installing freeglut ...
 echo.
 
 cmake -E make_directory "%BUILD_DIR%/freeglut" && cd "%BUILD_DIR%/freeglut"
-cmake %CMAKE_FLAGS% -DCMAKE_INSTALL_PREFIX="%INSTALL_DIR%"^
-      -DCMAKE_INSTALL_LIBDIR=lib^
+cmake %CMAKE_FLAGS% -DCMAKE_INSTALL_PREFIX="%INSTALL_DIR%" -DFREEGLUT_BUILD_DEMOS=Off^
+      -DCMAKE_INSTALL_LIBDIR=lib -DFREEGLUT_BUILD_STATIC_LIBS=Off^
       "%EXTERNALS_DIR%/freeglut/freeglut/freeglut" || exit /b
 
 cmake --build . --config %BUILD_TYPE% --target install --parallel 8

--- a/make_externals.sh
+++ b/make_externals.sh
@@ -86,7 +86,7 @@ echo ""
 
 cmake -E make_directory "$BUILD_DIR/freeglut" && cd "$BUILD_DIR/freeglut"
 cmake "${CMAKE_FLAGS[@]}" -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" \
-      -DCMAKE_INSTALL_LIBDIR=lib \
+      -DCMAKE_INSTALL_LIBDIR=lib -DFREEGLUT_BUILD_DEMOS=Off -DFREEGLUT_BUILD_STATIC_LIBS=Off \
       -DCMAKE_BUILD_TYPE=$BUILD_TYPE "$EXTERNALS_DIR/freeglut/freeglut/freeglut"
 cmake --build . --target install --parallel 8
 

--- a/make_externals.sh
+++ b/make_externals.sh
@@ -33,7 +33,7 @@ fi
 # Check if ComoScout VR debug build is enabled with "export COSMOSCOUT_DEBUG_BUILD=true".
 BUILD_TYPE=release
 case "$COSMOSCOUT_DEBUG_BUILD" in
-  (true) echo "CosmoScout VR debug build is enabled!"; BUILD_TYPE=debug;;
+  (true) echo "CosmoScout VR debug build is enabled!"; BUILD_TYPE=debug;
 esac
 
 # This directory should contain all submodules - they are assumed to reside in the subdirectory 

--- a/src/cosmoscout/main.cpp
+++ b/src/cosmoscout/main.cpp
@@ -20,6 +20,8 @@ int main(int argc, char** argv) {
   // others it blocks until the child process has terminated.
   cs::gui::executeWebProcess(argc, argv);
 
+  std::cout << "test" << std::endl;
+
   // parse program options -------------------------------------------------------------------------
 
   // These are the default values for the options.

--- a/src/cosmoscout/main.cpp
+++ b/src/cosmoscout/main.cpp
@@ -20,8 +20,6 @@ int main(int argc, char** argv) {
   // others it blocks until the child process has terminated.
   cs::gui::executeWebProcess(argc, argv);
 
-  std::cout << "test" << std::endl;
-
   // parse program options -------------------------------------------------------------------------
 
   // These are the default values for the options.


### PR DESCRIPTION
Finally I managed to use `ccache` and `clcache` to considerably speed up our build times on Github Actions. Speed-Up:

OS | Without Caching | With Caching
-- | -- | --
Windows | 90 minutes | 17 minutes
Linux | 25 minutes | 5 minutes

**If someone merges this, please create a Squash-Merge Commit! Maybe with this name:**

🎉 Use ccache and clcache for Github Actions
