### PR TITLE
Add icon to executable and window on Windows

### DIFF
--- a/src/cosmoscout/CMakeLists.txt
+++ b/src/cosmoscout/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 # build executable ---------------------------------------------------------------------------------
 
-file(GLOB SOURCE_FILES *.cpp */*.cpp)
+file(GLOB SOURCE_FILES *.cpp */*.cpp icon.rc)
 
 # Resoucre files and header files are only added in order to make them available in your IDE.
 file(GLOB HEADER_FILES *.hpp */*.hpp)

--- a/src/cosmoscout/icon.rc
+++ b/src/cosmoscout/icon.rc
@@ -1,0 +1,2 @@
+IDI_ICON1 ICON DISCARDABLE "..\\..\\resources\\icons\\icon.ico"
+GLUT_ICON ICON DISCARDABLE "..\\..\\resources\\icons\\icon.ico"


### PR DESCRIPTION
This adds an icon to the cosmoscout executable and to the glut window on Windows. For Linux, this is more involved...