### PR TITLE
Fix wrongly resized gui by waiting some frames

### DIFF
--- a/src/cs-gui/ScreenSpaceGuiArea.hpp
+++ b/src/cs-gui/ScreenSpaceGuiArea.hpp
@@ -49,10 +49,11 @@ class CS_GUI_EXPORT ScreenSpaceGuiArea : public GuiArea,
   virtual void onViewportChange();
 
   VistaViewport*   mViewport;
-  VistaGLSLShader* mShader      = nullptr;
-  bool             mShaderDirty = true;
-  int              mWidth       = 0;
-  int              mHeight      = 0;
+  VistaGLSLShader* mShader                = nullptr;
+  bool             mShaderDirty           = true;
+  int              mWidth                 = 0;
+  int              mHeight                = 0;
+  int              mDelayedViewportUpdate = 0;
 };
 
 } // namespace cs::gui


### PR DESCRIPTION
This "fixes" the occasional issue of of a wrongly resized gui. It's rather a workaround than a fix, but it does the trick and might actual increase the framerate during window resizing.