### PR TITLE
Fix a bug in the build_externals intruduced with CMake 3.17

### DIFF
--- a/make_externals.bat
+++ b/make_externals.bat
@@ -128,7 +128,7 @@ cmake -E make_directory "%BUILD_DIR%/curlpp" && cd "%BUILD_DIR%/curlpp"
 cmake %CMAKE_FLAGS% -DCMAKE_INSTALL_PREFIX="%INSTALL_DIR%"^
       -DCURL_INCLUDE_DIR="%INSTALL_DIR%/include"^
       -DCURL_LIBRARY="%INSTALL_DIR%/lib/%CURL_LIB%"^
-      -DCMAKE_INSTALL_LIBDIR=lib^
+      -DCMAKE_INSTALL_LIBDIR=lib -DCURL_NO_CURL_CMAKE=On^
       "%EXTERNALS_DIR%/curlpp" || exit /b
 
 cmake --build . --config %BUILD_TYPE% --target install --parallel %NUMBER_OF_PROCESSORS%

--- a/make_externals.sh
+++ b/make_externals.sh
@@ -134,7 +134,7 @@ cmake -E make_directory "$BUILD_DIR/curlpp" && cd "$BUILD_DIR/curlpp"
 cmake "${CMAKE_FLAGS[@]}" -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" \
       -DCURL_INCLUDE_DIR="$INSTALL_DIR/include" \
       -DCURL_LIBRARY="$INSTALL_DIR/lib/$CURL_LIB" \
-      -DCMAKE_INSTALL_LIBDIR=lib \
+      -DCMAKE_INSTALL_LIBDIR=lib -DCURL_NO_CURL_CMAKE=On \
       -DCMAKE_BUILD_TYPE=$BUILD_TYPE "$EXTERNALS_DIR/curlpp"
 cmake --build . --target install --parallel "$(nproc)"
 


### PR DESCRIPTION
CMake 3.17 changed the `FindCURL.cmake` script. This broke our build of curlpp. This merge request fixes this.

This fixes issue #134.