### PR TITLE
Feature/fix dropdown

### DIFF
--- a/resources/gui/js/apis/gui.js
+++ b/resources/gui/js/apis/gui.js
@@ -63,7 +63,7 @@ class GuiApi extends IApi {
       if (typeof dropdown.dataset.initialized === 'undefined') {
         dropdown.addEventListener('change', eventListener);
 
-        input.dataset.initialized = 'true';
+        dropdown.dataset.initialized = 'true';
       }
     });
   }

--- a/resources/gui/js/apis/gui.js
+++ b/resources/gui/js/apis/gui.js
@@ -59,7 +59,7 @@ class GuiApi extends IApi {
       }
     };
 
-    document.querySelectorAll('.simple-value-dropdown').forEach((dropdown) => {
+    document.querySelectorAll('div.simple-value-dropdown').forEach((dropdown) => {
       if (typeof dropdown.dataset.initialized === 'undefined') {
         dropdown.addEventListener('change', eventListener);
 

--- a/resources/gui/js/apis/gui.js
+++ b/resources/gui/js/apis/gui.js
@@ -62,6 +62,8 @@ class GuiApi extends IApi {
     document.querySelectorAll('.simple-value-dropdown').forEach((dropdown) => {
       if (typeof dropdown.dataset.initialized === 'undefined') {
         dropdown.addEventListener('change', eventListener);
+
+        input.dataset.initialized = 'true';
       }
     });
   }

--- a/resources/gui/js/apis/gui.js
+++ b/resources/gui/js/apis/gui.js
@@ -46,7 +46,7 @@ class GuiApi extends IApi {
    * @see {initInputs}
    */
   initDropDowns() {
-    const dropdowns = $('.simple-value-dropdown');
+    const dropdowns = $('select.simple-value-dropdown:not(div.dropdown > select)');
     dropdowns.selectpicker();
 
     const eventListener = (event) => {
@@ -59,7 +59,7 @@ class GuiApi extends IApi {
       }
     };
 
-    document.querySelectorAll('div.simple-value-dropdown').forEach((dropdown) => {
+    document.querySelectorAll('select.simple-value-dropdown').forEach((dropdown) => {
       if (typeof dropdown.dataset.initialized === 'undefined') {
         dropdown.addEventListener('change', eventListener);
 

--- a/src/cosmoscout/Application.cpp
+++ b/src/cosmoscout/Application.cpp
@@ -369,7 +369,7 @@ void Application::FrameUpdate() {
     // Every 25th frame something happens. At frame X we will show the name of the plugin on the
     // loading screen which will be loaded at frame X+25. At frame X+25 we will load the according
     // plugin and also update the loading screen to display the name of the plugin which is going to
-    // be loaded at fram X+50. And so on.
+    // be loaded at frame X+50. And so on.
     if (((GetFrameCount() - mStartPluginLoadingAtFrame) % cLoadingDelay) == 0) {
 
       // Calculate the index of the plugin which should be loaded this frame.


### PR DESCRIPTION
Event listeners were added to every `simple-value-dropdown` multiple times, since initialization wasn't checked. After fixing this, we still have 2 event listeners / dropdown. It looks like, `dropdowns.selectpicker()` creates a second dropdown element for each existing one (when I comment `dropdowns.selectpicker()` out, the loop iterates through the right amount of elements, when not, it is 2x more). Does anybody have any idea, why? 