### PR TITLE
Capture Depth Images

### DIFF
--- a/cmake/FindTIFF.cmake
+++ b/cmake/FindTIFF.cmake
@@ -11,9 +11,11 @@ find_path(TIFF_INCLUDE_DIR tiff.h
 # Locate library.
 find_library(TIFF_LIBRARY NAMES tiff tiffd
     HINTS ${TIFF_ROOT_DIR}/lib ${TIFF_ROOT_DIR}/lib64)
+find_library(TIFFXX_LIBRARY NAMES tiffxx tiffxxd
+    HINTS ${TIFF_ROOT_DIR}/lib ${TIFF_ROOT_DIR}/lib64)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(TIFF DEFAULT_MSG TIFF_INCLUDE_DIR TIFF_LIBRARY)
+find_package_handle_standard_args(TIFF DEFAULT_MSG TIFF_INCLUDE_DIR TIFF_LIBRARY TIFFXX_LIBRARY)
 
 # Add imported target.
 if(TIFF_FOUND)
@@ -22,6 +24,7 @@ if(TIFF_FOUND)
     if(NOT TIFF_FIND_QUIETLY)
         message(STATUS "TIFF_INCLUDE_DIRS ............. ${TIFF_INCLUDE_DIR}")
         message(STATUS "TIFF_LIBRARY .................. ${TIFF_LIBRARY}")
+        message(STATUS "TIFFXX_LIBRARY ................ ${TIFFXX_LIBRARY}")
     endif()
 
     if(NOT TARGET Tiff::Tiff)
@@ -31,5 +34,14 @@ if(TIFF_FOUND)
 
         set_property(TARGET Tiff::Tiff APPEND PROPERTY
             IMPORTED_LOCATION "${TIFF_LIBRARY}")
+    endif()
+
+    if(NOT TARGET Tiff::Tiffxx)
+        add_library(Tiff::Tiffxx UNKNOWN IMPORTED)
+        set_target_properties(Tiff::Tiffxx PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES "${TIFF_INCLUDE_DIRS}")
+
+        set_property(TARGET Tiff::Tiffxx APPEND PROPERTY
+            IMPORTED_LOCATION "${TIFFXX_LIBRARY}")
     endif()
 endif()

--- a/make_externals.bat
+++ b/make_externals.bat
@@ -157,7 +157,7 @@ echo.
 
 cmake -E make_directory "%BUILD_DIR%/libtiff" && cd "%BUILD_DIR%/libtiff"
 cmake %CMAKE_FLAGS% -DCMAKE_INSTALL_PREFIX="%INSTALL_DIR%" -DCMAKE_UNITY_BUILD=%UNITY_BUILD%^
-      -DCMAKE_INSTALL_FULL_LIBDIR=lib^
+      -DBUILD_SHARED_LIBS=Off -DCMAKE_INSTALL_FULL_LIBDIR=lib^
       "%EXTERNALS_DIR%/libtiff" || exit /b
 
 cmake --build . --config %BUILD_TYPE% --target install --parallel %NUMBER_OF_PROCESSORS%

--- a/src/cosmoscout/Application.cpp
+++ b/src/cosmoscout/Application.cpp
@@ -255,22 +255,22 @@ void Application::FrameUpdate() {
 
   // loading and saving ----------------------------------------------------------------------------
 
-  if (!mSettingsToWrite.empty()) {
+  if (!mSettingsToSave.empty()) {
     try {
-      mSettings->write(mSettingsToWrite);
+      mSettings->saveToFile(mSettingsToSave);
     } catch (std::exception const& e) {
-      logger().warn("Failed to save settings to '{}': {}", mSettingsToWrite, e.what());
+      logger().warn("Failed to save settings to '{}': {}", mSettingsToSave, e.what());
     }
-    mSettingsToWrite = "";
+    mSettingsToSave = "";
   }
 
-  if (!mSettingsToRead.empty()) {
+  if (!mSettingsToLoad.empty()) {
     try {
-      mSettings->read(mSettingsToRead);
+      mSettings->loadFromFile(mSettingsToLoad);
     } catch (std::exception const& e) {
-      logger().warn("Failed to load settings from '{}': {}", mSettingsToRead, e.what());
+      logger().warn("Failed to load settings from '{}': {}", mSettingsToLoad, e.what());
     }
-    mSettingsToRead = "";
+    mSettingsToLoad = "";
 
     // Unload all plugins we do not need anymore.
     for (auto const& plugin : mPlugins) {
@@ -854,11 +854,11 @@ void Application::registerGuiCallbacks() {
   // Saves the current scene state in a specified file.
   mGuiManager->getGui()->registerCallback("core.save",
       "Saves the current scene state to the given file.",
-      std::function([this](std::string&& file) { mSettingsToWrite = file; }));
+      std::function([this](std::string&& file) { mSettingsToSave = file; }));
 
   // Loads a scene state from a specified file.
   mGuiManager->getGui()->registerCallback("core.load", "Loads a scene state from the given file.",
-      std::function([this](std::string&& file) { mSettingsToRead = file; }));
+      std::function([this](std::string&& file) { mSettingsToLoad = file; }));
 
   // Unloads a plugin.
   mGuiManager->getGui()->registerCallback("core.unloadPlugin",

--- a/src/cosmoscout/Application.hpp
+++ b/src/cosmoscout/Application.hpp
@@ -191,10 +191,10 @@ class Application : public VistaFrameLoop {
   std::set<std::string> mPluginsToLoad;
 
   // For deferred reloading of settings.
-  std::string mSettingsToRead;
+  std::string mSettingsToLoad;
 
   // For deferred writing of settings.
-  std::string mSettingsToWrite;
+  std::string mSettingsToSave;
 };
 
 #endif // CS_APPLICATION_HPP

--- a/src/cosmoscout/main.cpp
+++ b/src/cosmoscout/main.cpp
@@ -96,7 +96,7 @@ int main(int argc, char** argv) {
 
   auto settings = std::make_shared<cs::core::Settings>();
   try {
-    settings->read(settingsFile);
+    settings->loadFromFile(settingsFile);
   } catch (std::exception const& e) {
     logger().error("Failed to read settings: {}", e.what());
     return 1;

--- a/src/cs-core/Settings.cpp
+++ b/src/cs-core/Settings.cpp
@@ -286,7 +286,7 @@ utils::Signal<> const& Settings::onSave() const {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-void Settings::read(std::string const& fileName) {
+void Settings::loadFromFile(std::string const& fileName) {
   std::ifstream i(fileName);
 
   if (!i) {
@@ -304,7 +304,18 @@ void Settings::read(std::string const& fileName) {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-void Settings::write(std::string const& fileName) const {
+void Settings::loadFromJson(std::string const& json) {
+
+  nlohmann::json settings = nlohmann::json::parse(json);
+  from_json(settings, *this);
+
+  // Notify listeners that values might have changed.
+  mOnLoad.emit();
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+void Settings::saveToFile(std::string const& fileName) const {
   // Tell listeners that the settings are about to be saved.
   mOnSave.emit();
 
@@ -325,6 +336,21 @@ void Settings::write(std::string const& fileName) const {
 
   // All done, so we're safe to rename the file.
   std::rename((fileName + ".tmp").c_str(), fileName.c_str());
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+std::string Settings::saveToJson() const {
+  // Tell listeners that the settings are about to be saved.
+  mOnSave.emit();
+
+  nlohmann::json settings = *this;
+
+  // Use an indentation of two space.
+  std::ostringstream o;
+  o << std::setw(2) << settings;
+
+  return o.str();
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/cs-core/Settings.hpp
+++ b/src/cs-core/Settings.hpp
@@ -116,11 +116,19 @@ class CS_CORE_EXPORT Settings {
 
   /// Initializes all members from a given JSON file. Once reading finished, the onLoad signal will
   /// be emitted.
-  void read(std::string const& fileName);
+  void loadFromFile(std::string const& fileName);
+
+  /// Initializes all members from a given JSON object. Once reading finished, the onLoad signal
+  /// will be emitted.
+  void loadFromJson(std::string const& json);
 
   /// Writes the current settings to a JSON file. Before the state is written to file, the onSave
   /// signal will be emitted.
-  void write(std::string const& fileName) const;
+  void saveToFile(std::string const& fileName) const;
+
+  /// Writes the current settings to a JSON object. Before the state is stored, the onSave
+  /// signal will be emitted.
+  std::string saveToJson() const;
 
   // -----------------------------------------------------------------------------------------------
 

--- a/src/cs-utils/CMakeLists.txt
+++ b/src/cs-utils/CMakeLists.txt
@@ -30,6 +30,7 @@ target_link_libraries(cs-utils
     OpenSG::base
     OpenSG::system
     Tiff::Tiff
+    Tiff::Tiffxx
     ${VISTACORELIBS_LIBRARIES}
     ${CMAKE_DL_LIBS}
     cspice::cspice


### PR DESCRIPTION
This adds the following features:

* Save and load the scene from and to a json string (instead of a json file).
* A `/save` and a `/load` endpoint for `csp-web-api` which allows, well, saving and loading of the scene via http.
* A `&depth=true|false` parameter to the /capture endpoint of `csp-web-api` to allow capturing of 32 bit tiff depth images.

I forgot to create a feature branch for `csp-web-api`, here's the diff: https://github.com/cosmoscout/csp-web-api/compare/259f00b28e26009bb6f7ffc78ece7fbeb7ca3b89...develop