### PR TITLE
Add possibiltity to auto-hide window headers

### DIFF
--- a/resources/gui/cosmoscout.html
+++ b/resources/gui/cosmoscout.html
@@ -632,7 +632,7 @@
                 id="bookmark-editor-frame">
               <div class="input-group-append">
                 <button class="btn glass" type="button" data-toggle="tooltip"
-                  title="Use current Planet"><i class="material-icons">place</i></button>
+                  title="Use current Body"><i class="material-icons">place</i></button>
               </div>
               <div class="invalid-feedback"></div>
             </div>

--- a/resources/gui/cosmoscout.html
+++ b/resources/gui/cosmoscout.html
@@ -499,188 +499,194 @@
 
     <!-- Calendar -->
 
-    <div id="calendar" class="draggable-window resizable-window">
-      <div class="window-header">
-        <span class="window-title"><i
-            class="material-icons">date_range</i><span>Calendar</span></span>
-        <a class="btn light-glass" data-action="lock" data-toggle="tooltip" title="Keep open">
-          <i class="material-icons">lock_open</i>
-        </a>
-        <a class="btn light-glass" data-action="close" data-toggle="tooltip" title="Close">
-          <i class="material-icons">close</i>
-        </a>
-      </div>
-      <div class="window-content">
+    <div id="calendar" class="draggable-window resizable-window auto-hide-header">
+      <div class="window-wrapper">
+        <div class="window-header">
+          <span class="window-title"><i
+              class="material-icons">date_range</i><span>Calendar</span></span>
+          <a class="btn light-glass" data-action="lock" data-toggle="tooltip" title="Keep open">
+            <i class="material-icons">lock_open</i>
+          </a>
+          <a class="btn light-glass" data-action="close" data-toggle="tooltip" title="Close">
+            <i class="material-icons">close</i>
+          </a>
+        </div>
+        <div class="window-content">
+        </div>
       </div>
     </div>
 
     <!-- Bookmark Editor -->
 
     <div id="bookmark-editor" class="draggable-window resizable-window">
-      <div class="window-header">
-        <div class="window-title"><i class="material-icons">bookmark</i><span
-            id="bookmark-editor-title">Bookmark Editor</span>
+      <div class="window-wrapper">
+        <div class="window-header">
+          <div class="window-title"><i class="material-icons">bookmark</i><span
+              id="bookmark-editor-title">Bookmark Editor</span>
+          </div>
+          <a class="btn light-glass" data-action="close" data-toggle="tooltip" title="Close">
+            <i class="material-icons">close</i>
+          </a>
         </div>
-        <a class="btn light-glass" data-action="close" data-toggle="tooltip" title="Close">
-          <i class="material-icons">close</i>
-        </a>
-      </div>
-      <div class="window-content container-fluid">
+        <div class="window-content container-fluid">
 
-        <div class="row">
+          <div class="row">
 
-          <div class="col-12 mb-1">
-            <div class="invalid-feedback" id="bookmark-editor-nothing-given-error">
-              You should either specify a time or a location for the bookmark.
+            <div class="col-12 mb-1">
+              <div class="invalid-feedback" id="bookmark-editor-nothing-given-error">
+                You should either specify a time or a location for the bookmark.
+              </div>
+              <small class="form-text text-muted">The name is required, the description is
+                optional.</small>
             </div>
-            <small class="form-text text-muted">The name is required, the description is
-              optional.</small>
-          </div>
-        </div>
-
-        <div class="row mb-3">
-          <div class="col" style="flex-grow: 0;">
-            <a tabindex="0" id="bookmark-editor-icon-select-button" class="btn block glass"
-              data-trigger="focus" data-toggle="popover"
-              data-popover-content="#bookmark-editor-icon-select-popover">
-              <span>Icon</span>
-              <img class="img-fluid" src="">
-            </a>
           </div>
 
-          <div class="hidden" id="bookmark-editor-icon-select-popover">
-            <div class="data-popover-header"> </div>
-            <div class="data-popover-body">
-              <div id="bookmark-editor-icon-select-list" class="row px-2">
-                <div class="col-3 p-1 d-flex">
-                  <a class="btn block glass pt-3" data-icon="none">
-                    None
-                  </a>
+          <div class="row mb-3">
+            <div class="col" style="flex-grow: 0;">
+              <a tabindex="0" id="bookmark-editor-icon-select-button" class="btn block glass"
+                data-trigger="focus" data-toggle="popover"
+                data-popover-content="#bookmark-editor-icon-select-popover">
+                <span>Icon</span>
+                <img class="img-fluid" src="">
+              </a>
+            </div>
+
+            <div class="hidden" id="bookmark-editor-icon-select-popover">
+              <div class="data-popover-header"> </div>
+              <div class="data-popover-body">
+                <div id="bookmark-editor-icon-select-list" class="row px-2">
+                  <div class="col-3 p-1 d-flex">
+                    <a class="btn block glass pt-3" data-icon="none">
+                      None
+                    </a>
+                  </div>
+                </div>
+                <small class="muted">Place PNG images into ../share/resources/icons to make
+                  them available here.</small>
+              </div>
+            </div>
+
+            <div class="col">
+              <div class="row mb-1">
+                <div class="col-8">
+                  <input type="text" placeholder="Bookmark Name" class="form-control"
+                    id="bookmark-editor-name">
+                  <div class="invalid-feedback"></div>
+                </div>
+                <div class="col-4">
+                  <input type="text" class="form-control color-input" id="bookmark-editor-color"
+                    style="color: black;" value="">
                 </div>
               </div>
-              <small class="muted">Place PNG images into ../share/resources/icons to make
-                them available here.</small>
+
+              <div class="row">
+                <div class="col-12">
+                  <input type="text" placeholder="Description" class="form-control"
+                    id="bookmark-editor-description">
+                  <div class="invalid-feedback"></div>
+                </div>
+              </div>
             </div>
           </div>
 
-          <div class="col">
-            <div class="row mb-1">
-              <div class="col-8">
-                <input type="text" placeholder="Bookmark Name" class="form-control"
-                  id="bookmark-editor-name">
+          <div class="row mb-3">
+            <div class="col-12 mb-1">
+              <small class="form-text text-muted">If you specify one or two dates, the bookmark will
+                be shown on the timeline.</small>
+            </div>
+            <div class="col-6">
+              <div class="input-group">
+                <input type="text" placeholder="Start Date" class="form-control"
+                  id="bookmark-editor-start-date">
+                <div class="input-group-append">
+                  <button class="btn glass" type="button" data-toggle="tooltip"
+                    title="Use current time"><i class="material-icons">update</i></button>
+                </div>
                 <div class="invalid-feedback"></div>
               </div>
-              <div class="col-4">
-                <input type="text" class="form-control color-input" id="bookmark-editor-color"
-                  style="color: black;" value="">
-              </div>
             </div>
-
-            <div class="row">
-              <div class="col-12">
-                <input type="text" placeholder="Description" class="form-control"
-                  id="bookmark-editor-description">
+            <div class="col-6">
+              <div class=" input-group">
+                <input type="text" placeholder="End Date" class="form-control"
+                  id="bookmark-editor-end-date">
+                <div class="input-group-append">
+                  <button class="btn glass" type="button" data-toggle="tooltip"
+                    title="Use current time"><i class="material-icons">update</i></button>
+                </div>
                 <div class="invalid-feedback"></div>
               </div>
             </div>
           </div>
-        </div>
 
-        <div class="row mb-3">
-          <div class="col-12 mb-1">
-            <small class="form-text text-muted">If you specify one or two dates, the bookmark will
-              be shown on the timeline.</small>
-          </div>
-          <div class="col-6">
-            <div class="input-group">
-              <input type="text" placeholder="Start Date" class="form-control"
-                id="bookmark-editor-start-date">
+          <div class="row mb-2">
+            <div class="col-12 mb-1">
+              <small class="form-text text-muted">The location fields are required top to bottom:
+                You may omit them all, but if you provide a rotation, all fields are
+                required.</small>
+            </div>
+
+            <div class="col-12 input-group">
+              <input type="text" placeholder="Center" class="form-control"
+                id="bookmark-editor-center">
+              <input type="text" placeholder="Frame" class="form-control"
+                id="bookmark-editor-frame">
               <div class="input-group-append">
                 <button class="btn glass" type="button" data-toggle="tooltip"
-                  title="Use current time"><i class="material-icons">update</i></button>
+                  title="Use current Planet"><i class="material-icons">place</i></button>
               </div>
               <div class="invalid-feedback"></div>
             </div>
           </div>
-          <div class="col-6">
-            <div class=" input-group">
-              <input type="text" placeholder="End Date" class="form-control"
-                id="bookmark-editor-end-date">
+
+          <div class="row mb-2">
+            <div class="col-12 input-group">
+              <input id="bookmark-editor-location-x" type="text" class="form-control"
+                placeholder="LocX">
+              <input id="bookmark-editor-location-y" type="text" class="form-control"
+                placeholder="LocY">
+              <input id="bookmark-editor-location-z" type="text" class="form-control"
+                placeholder="LocZ">
               <div class="input-group-append">
                 <button class="btn glass" type="button" data-toggle="tooltip"
-                  title="Use current time"><i class="material-icons">update</i></button>
+                  title="Use current position"><i class="material-icons">place</i></button>
               </div>
               <div class="invalid-feedback"></div>
             </div>
           </div>
-        </div>
 
-        <div class="row mb-2">
-          <div class="col-12 mb-1">
-            <small class="form-text text-muted">The location fields are required top to bottom: You
-              may omit them all, but if you provide a rotation, all fields are required.</small>
-          </div>
-
-          <div class="col-12 input-group">
-            <input type="text" placeholder="Center" class="form-control"
-              id="bookmark-editor-center">
-            <input type="text" placeholder="Frame" class="form-control" id="bookmark-editor-frame">
-            <div class="input-group-append">
-              <button class="btn glass" type="button" data-toggle="tooltip"
-                title="Use current Planet"><i class="material-icons">place</i></button>
+          <div class="row mb-2">
+            <div class="col-12 input-group">
+              <input id="bookmark-editor-rotation-x" type="text" class="form-control"
+                placeholder="RotX">
+              <input id="bookmark-editor-rotation-y" type="text" class="form-control"
+                placeholder="RotY">
+              <input id="bookmark-editor-rotation-z" type="text" class="form-control"
+                placeholder="RotZ">
+              <input id="bookmark-editor-rotation-w" type="text" class="form-control "
+                placeholder="RotW">
+              <div class="input-group-append">
+                <button class="btn glass" type="button" data-toggle="tooltip"
+                  title="Use current rotation"><i class="material-icons">place</i></button>
+              </div>
+              <div class="invalid-feedback"></div>
             </div>
-            <div class="invalid-feedback"></div>
+
           </div>
+
         </div>
 
-        <div class="row mb-2">
-          <div class="col-12 input-group">
-            <input id="bookmark-editor-location-x" type="text" class="form-control"
-              placeholder="LocX">
-            <input id="bookmark-editor-location-y" type="text" class="form-control"
-              placeholder="LocY">
-            <input id="bookmark-editor-location-z" type="text" class="form-control"
-              placeholder="LocZ">
-            <div class="input-group-append">
-              <button class="btn glass" type="button" data-toggle="tooltip"
-                title="Use current position"><i class="material-icons">place</i></button>
+        <div class="window-action-area container-fluid">
+          <div class="row mb-2">
+            <div class="col-5">
+              <button class="btn glass btn-danger block" id="bookmark-editor-delete-button">
+                Delete Bookmark
+              </button>
             </div>
-            <div class="invalid-feedback"></div>
-          </div>
-        </div>
-
-        <div class="row mb-2">
-          <div class="col-12 input-group">
-            <input id="bookmark-editor-rotation-x" type="text" class="form-control"
-              placeholder="RotX">
-            <input id="bookmark-editor-rotation-y" type="text" class="form-control"
-              placeholder="RotY">
-            <input id="bookmark-editor-rotation-z" type="text" class="form-control"
-              placeholder="RotZ">
-            <input id="bookmark-editor-rotation-w" type="text" class="form-control "
-              placeholder="RotW">
-            <div class="input-group-append">
-              <button class="btn glass" type="button" data-toggle="tooltip"
-                title="Use current rotation"><i class="material-icons">place</i></button>
+            <div class="col-7">
+              <button class="btn glass block" id="bookmark-editor-save-button">
+                Save Bookmark
+              </button>
             </div>
-            <div class="invalid-feedback"></div>
-          </div>
-
-        </div>
-
-      </div>
-
-      <div class="window-action-area container-fluid">
-        <div class="row mb-2">
-          <div class="col-5">
-            <button class="btn glass btn-danger block" id="bookmark-editor-delete-button">
-              Delete Bookmark
-            </button>
-          </div>
-          <div class="col-7">
-            <button class="btn glass block" id="bookmark-editor-save-button">
-              Save Bookmark
-            </button>
           </div>
         </div>
       </div>

--- a/resources/gui/css/calendar.css
+++ b/resources/gui/css/calendar.css
@@ -1,5 +1,6 @@
 #calendar {
-  width: 500px;
+  width: 400px;
+  height: 400px;
 }
 
 .datepicker table,
@@ -14,10 +15,14 @@
   opacity: 0.2;
 }
 
-.datepicker table tr th,
-.datepicker table tr td {
+.datepicker table tr th {
   text-align: center;
   padding: 10px 5px;
+}
+
+.datepicker table tr td {
+  text-align: center;
+  padding: 0px;
 }
 
 .datepicker .datepicker-switch,

--- a/resources/gui/css/gui.css
+++ b/resources/gui/css/gui.css
@@ -783,6 +783,7 @@ hr {
 .resizable-window {
   resize: both;
   overflow: hidden;
+  border-radius: 5px;
 }
 
 /* This thing is required to make the resize-grip clickable even if a link is beneath it */
@@ -805,16 +806,11 @@ hr {
 /* Movable Windows ------------------------------------------------------------------------------ */
 
 .draggable-window {
-  display: flex;
-  flex-direction: column;
-  position: absolute;
+  padding-top: 20px;
   opacity: 0;
+  position: absolute;
   transition: opacity 0.2s ease-out;
   pointer-events: none;
-  background: rgba(10, 10, 10, 0.9);
-  border: 2px solid var(--cs-border-color);
-  border-radius: 5px;
-  box-shadow: 0 5px 20px rgba(0, 0, 0, 0.5);
 }
 
 .draggable-window.visible {
@@ -822,10 +818,22 @@ hr {
   opacity: 1;
 }
 
+.draggable-window .window-wrapper {
+  position: relative;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: rgba(10, 10, 10, 0.9);
+  border: 2px solid var(--cs-border-color);
+  border-radius: 5px;
+  box-shadow: 0 5px 20px rgba(0, 0, 0, 0.5);
+}
+
 .draggable-window .window-header {
   display: flex;
   font-size: 1.2rem;
   border-bottom: 1px dashed rgba(230, 230, 255, 0.3);
+  height: 47px;
 }
 
 .draggable-window .window-header:hover {
@@ -833,6 +841,9 @@ hr {
 }
 
 .draggable-window .window-title {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
   position: relative;
   flex-grow: 1;
   padding: 5px;
@@ -857,6 +868,27 @@ hr {
 
 .draggable-window .window-title i {
   padding: 0 10px;
+}
+
+
+.draggable-window.auto-hide-header .window-header::before {
+  content: '';
+  position: absolute;
+  top: -20px;
+  height: 20px;
+  width: 100%;
+}
+
+.draggable-window.auto-hide-header .window-header {
+  border-bottom-width: 0px;
+  height: 0px;
+  overflow: hidden;
+  transition: height 0.2s ease, border-width 0.2s ease;
+}
+
+.draggable-window.auto-hide-header .window-header:hover {
+  height: 47px;
+  border-bottom-width: 1px;
 }
 
 /* color picker --------------------------------------------------------------------------------- */


### PR DESCRIPTION
With the class `.auto-hide-header` window title bars can now be hidden automatically. This reduces screen clutter and is currently used for the calendar and will be used for the minimap soon. The title bar is revealed when the pointer is above the window.

In `cosmoscout.html` actually only four lines changed because a `<div class="window-wrapper">` was added. The rest is indentation. :open_mouth: 