### PR TITLE
Add possibility to specify a fixed sun direction

### DIFF
--- a/src/cosmoscout/Application.cpp
+++ b/src/cosmoscout/Application.cpp
@@ -1175,6 +1175,14 @@ void Application::registerGuiCallbacks() {
   mSettings->mGraphics.pEnableVsync.connectAndTouch(
       [this](bool enable) { mGuiManager->setCheckboxValue("graphics.setEnableVsync", enable); });
 
+  // Enables or disables the fixed sun position.
+  mGuiManager->getGui()->registerCallback("graphics.setFixedSunDirection",
+      "This makes illumination calculations assume a fixed sun direction in the current SPICE "
+      "frame. Using three zeros disables this feature.",
+      std::function([this](double x, double y, double z) {
+        mSettings->mGraphics.pFixedSunDirection = glm::dvec3(x, y, z);
+      }));
+
   // Bookmark callbacks ----------------------------------------------------------------------------
 
   // Remove bookmarks.
@@ -1581,6 +1589,7 @@ void Application::unregisterGuiCallbacks() {
   mGuiManager->getGui()->unregisterCallback("graphics.setEnableAutoGlow");
   mGuiManager->getGui()->unregisterCallback("graphics.setGlowIntensity");
   mGuiManager->getGui()->unregisterCallback("graphics.setExposureRange");
+  mGuiManager->getGui()->unregisterCallback("graphics.setFixedSunPosition");
   mGuiManager->getGui()->unregisterCallback("navigation.fixHorizon");
   mGuiManager->getGui()->unregisterCallback("navigation.northUp");
   mGuiManager->getGui()->unregisterCallback("navigation.setBody");

--- a/src/cs-core/Settings.cpp
+++ b/src/cs-core/Settings.cpp
@@ -210,6 +210,7 @@ void from_json(nlohmann::json const& j, Settings::Graphics& o) {
   Settings::deserialize(j, "ambientBrightness", o.pAmbientBrightness);
   Settings::deserialize(j, "enableAutoGlow", o.pEnableAutoGlow);
   Settings::deserialize(j, "glowIntensity", o.pGlowIntensity);
+  Settings::deserialize(j, "fixedSunDirection", o.pFixedSunDirection);
 }
 
 void to_json(nlohmann::json& j, Settings::Graphics const& o) {
@@ -238,6 +239,7 @@ void to_json(nlohmann::json& j, Settings::Graphics const& o) {
   Settings::serialize(j, "ambientBrightness", o.pAmbientBrightness);
   Settings::serialize(j, "enableAutoGlow", o.pEnableAutoGlow);
   Settings::serialize(j, "glowIntensity", o.pGlowIntensity);
+  Settings::serialize(j, "fixedSunDirection", o.pFixedSunDirection);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/cs-core/Settings.hpp
+++ b/src/cs-core/Settings.hpp
@@ -404,6 +404,10 @@ class CS_CORE_EXPORT Settings {
 
     /// The amount of artifical glare. Has no effect if HDR rendering is disabled.
     utils::DefaultProperty<float> pGlowIntensity{0.5F};
+
+    /// This makes illumination calculations assume a fixed sun position in the current SPICE frame.
+    /// Using the default value glm::dvec3(0.0) disables this feature.
+    utils::DefaultProperty<glm::dvec3> pFixedSunDirection{glm::dvec3(0.0, 0.0, 0.0)};
   };
 
   Graphics mGraphics;


### PR DESCRIPTION
This adds the possibility to create artificial lighting conditions. This is for example required to generate training data for crater detection.

This will make all bodies be lit from their south pole:

```javascript
CosmoScout.callbacks.graphics.setFixedSunDirection(0, -1, 0)
```

Use this to disable the feature again:

```javascript
CosmoScout.callbacks.graphics.setFixedSunDirection(0, 0, 0)
```