### PR TITLE
Allow multiples calls to CelestialObserver::moveTo per frame

### DIFF
--- a/src/cs-scene/CelestialObserver.cpp
+++ b/src/cs-scene/CelestialObserver.cpp
@@ -68,32 +68,41 @@ void CelestialObserver::moveTo(std::string const& sCenterName, std::string const
     double dRealStartTime, double dRealEndTime) {
   mAnimationInProgress = false;
 
-  cs::scene::CelestialAnchor target(sCenterName, sFrameName);
+  // Perform no animation at all if end time is not greater than start time.
+  if (dRealStartTime >= dRealEndTime) {
+    setCenterName(sCenterName);
+    setFrameName(sFrameName);
+    setAnchorRotation(rotation);
+    setAnchorPosition(position);
 
-  glm::dvec3 startPos = target.getRelativePosition(dSimulationTime, *this);
-  glm::dquat startRot = target.getRelativeRotation(dSimulationTime, *this);
+  } else {
+    cs::scene::CelestialAnchor target(sCenterName, sFrameName);
 
-  setCenterName(sCenterName);
-  setFrameName(sFrameName);
+    glm::dvec3 startPos = target.getRelativePosition(dSimulationTime, *this);
+    glm::dquat startRot = target.getRelativeRotation(dSimulationTime, *this);
 
-  double cosTheta = glm::dot(startRot, rotation);
+    setCenterName(sCenterName);
+    setFrameName(sFrameName);
 
-  // If cosTheta < 0, the interpolation will take the long way around the sphere.
-  // To fix this, one quat must be negated.
-  if (cosTheta < 0.0) {
-    startRot = -startRot;
+    double cosTheta = glm::dot(startRot, rotation);
+
+    // If cosTheta < 0, the interpolation will take the long way around the sphere.
+    // To fix this, one quat must be negated.
+    if (cosTheta < 0.0) {
+      startRot = -startRot;
+    }
+
+    setAnchorRotation(startRot);
+    setAnchorPosition(startPos);
+
+    mAnimatedPosition = utils::AnimatedValue<glm::dvec3>(
+        startPos, position, dRealStartTime, dRealEndTime, utils::AnimationDirection::eInOut);
+
+    mAnimatedRotation = utils::AnimatedValue<glm::dquat>(
+        startRot, rotation, dRealStartTime, dRealEndTime, utils::AnimationDirection::eInOut);
+
+    mAnimationInProgress = true;
   }
-
-  setAnchorRotation(startRot);
-  setAnchorPosition(startPos);
-
-  mAnimatedPosition = utils::AnimatedValue<glm::dvec3>(
-      startPos, position, dRealStartTime, dRealEndTime, utils::AnimationDirection::eInOut);
-
-  mAnimatedRotation = utils::AnimatedValue<glm::dquat>(
-      startRot, rotation, dRealStartTime, dRealEndTime, utils::AnimationDirection::eInOut);
-
-  mAnimationInProgress = true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Even if the animation time was set to zero, it took one frame to update the observer's position and rotation. Hence multiple calls to CelestialObserver::moveTo would "overwrite" each other.

Calling something like this didn't work (but does now):

```javascript
CosmoScout.callbacks.navigation.setPosition(x, y, z, 0);
CosmoScout.callbacks.navigation.setRotation(x, y, z, w, 0);
```