### PR TITLE
:wrench: Capitalize build types to match CMake and VS conventions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,22 +105,22 @@ jobs:
           -DCOSMOSCOUT_COVERAGE_INFO=On -DCOSMOSCOUT_UNIT_TESTS=On
           -DBOOST_ROOT=$BOOST_ROOT_1_69_0 -DBoost_ARCHITECTURE=-x64
       - name: Run Tests
-        run: ./install/linux-release/bin/run_tests.sh
+        run: ./install/linux-Release/bin/run_tests.sh
       - name: Run Graphical Tests
-        run: ./install/linux-release/bin/run_graphical_tests.sh
+        run: ./install/linux-Release/bin/run_graphical_tests.sh
       - name: Upload Results of Failed Test
         uses: actions/upload-artifact@v1
         if: failure()
         with:
           name: graphical-test-results-gcc
-          path: install/linux-release/bin/test
+          path: install/linux-Release/bin/test
       - name: Calculate Test Coverage
         run: ./lcov.sh
       - name: Upload Coverage Info
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./build/linux-release/coverage.info
+          path-to-lcov: ./build/linux-Release/coverage.info
       - name: Print ccache Statistics
         run: ccache -s
 
@@ -166,15 +166,15 @@ jobs:
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
           -DCOSMOSCOUT_UNIT_TESTS=On -DBOOST_ROOT=$BOOST_ROOT_1_69_0 -DBoost_ARCHITECTURE=-x64
       - name: Run Tests
-        run: ./install/linux-release/bin/run_tests.sh
+        run: ./install/linux-Release/bin/run_tests.sh
       - name: Run Graphical Tests
-        run: ./install/linux-release/bin/run_graphical_tests.sh
+        run: ./install/linux-Release/bin/run_graphical_tests.sh
       - name: Upload Results of Failed Test
         uses: actions/upload-artifact@v1
         if: failure()
         with:
           name: graphical-test-results-clang
-          path: install/linux-release/bin/test
+          path: install/linux-Release/bin/test
       - name: Print ccache Statistics
         run: ccache -s
 
@@ -215,6 +215,6 @@ jobs:
           -DCOSMOSCOUT_UNIT_TESTS=On -DBOOST_ROOT=%BOOST_ROOT_1_72_0%
       - name: Run Tests
         shell: cmd
-        run: install\\windows-release\\bin\\run_tests.bat
+        run: install\\windows-Release\\bin\\run_tests.bat
       - name: Print clcache Statistics
         run: clcache -s

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,7 @@ jobs:
       run: ./make.sh -G "Unix Makefiles" -DBOOST_ROOT=$BOOST_ROOT_1_69_0 -DBoost_ARCHITECTURE=-x64
     - name: Create Release
       run: | 
-        mv install/linux-release cosmoscout-vr
+        mv install/linux-Release cosmoscout-vr
         cmake -E tar cv cosmoscout-vr-linux64.tar.gz cosmoscout-vr
     - name: Upload Release
       uses: svenstaro/upload-release-action@v1-release
@@ -71,7 +71,7 @@ jobs:
       run: make.bat -G "Visual Studio 16 2019" -A x64 -DBOOST_ROOT=%BOOST_ROOT_1_72_0%
     - name: Create Release
       run: | 
-        move install\windows-release cosmoscout-vr
+        move install\windows-Release cosmoscout-vr
         cmake -E tar cv cosmoscout-vr-win64.zip --format=zip cosmoscout-vr
     - name: Upload Release
       uses: svenstaro/upload-release-action@v1-release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,10 +16,10 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 # CMAKE_BUILD_TYPE must be set (except for Visual Studio).
 if(NOT MSVC)
   if(NOT CMAKE_BUILD_TYPE OR
-    (NOT ${CMAKE_BUILD_TYPE} STREQUAL "release" AND
-    NOT ${CMAKE_BUILD_TYPE} STREQUAL "debug"))
+    (NOT ${CMAKE_BUILD_TYPE} STREQUAL "Release" AND
+    NOT ${CMAKE_BUILD_TYPE} STREQUAL "Debug"))
 
-    set(CMAKE_BUILD_TYPE "release" CACHE STRING "release or debug" FORCE)
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Release or Debug" FORCE)
   endif()
 endif()
 

--- a/clang-tidy.sh
+++ b/clang-tidy.sh
@@ -7,17 +7,17 @@
 # ------------------------------------------------------------------------------------------------ #
 
 # For this script to work, CosmoScout has to be built at least once in release mode, as the
-# build/linux-release directory is required. The directory is assumed to reside next to this script
+# build/linux-Release directory is required. The directory is assumed to reside next to this script
 # or one level above.
 SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
 
 # Run clang-tidy on all source files
-if [ -d "$SCRIPT_DIR/build/linux-release" ] 
+if [ -d "$SCRIPT_DIR/build/linux-Release" ] 
 then
-  run-clang-tidy -fix -quiet -p "$SCRIPT_DIR/build/linux-release"
-elif [ -d "$SCRIPT_DIR/../build/linux-release" ] 
+  run-clang-tidy -fix -quiet -p "$SCRIPT_DIR/build/linux-Release"
+elif [ -d "$SCRIPT_DIR/../build/linux-Release" ] 
 then
-  run-clang-tidy -fix -quiet -p "$SCRIPT_DIR/../build/linux-release"
+  run-clang-tidy -fix -quiet -p "$SCRIPT_DIR/../build/linux-Release"
 else
     echo "Failed to find build directory!"
 fi

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -46,12 +46,12 @@ You can run them with the following scripts.
 #### Linux:
 
 ```shell
-./install/linux-release/run_tests.sh
+./install/linux-Release/run_tests.sh
 ```
 
 #### Windows:
 ```batch
-install\linux-release\run_tests.bat
+install\windows-Release\run_tests.bat
 ```
 
 ### Graphical Tests
@@ -63,7 +63,7 @@ In order to make them possible even if there is no graphics card or display atta
 Graphical tests can only be executed on Linux for now:
 
 ```shell
-./install/linux-release/run_graphical_tests.sh
+./install/linux-Release/run_graphical_tests.sh
 ```
 
 <p align="center"><img src ="img/hr.svg"/></p>

--- a/docs/ide-setup.md
+++ b/docs/ide-setup.md
@@ -28,39 +28,39 @@ export VISTACORELIBS_DRIVER_PLUGIN_DIRS=../lib/DriverPlugins
 - Run: `./make.sh`
 - Go to: _Settings_ -> _Build, Execution, Deployment_ -> _CMake_
 - Release Profile
-  - _Generation path_: `build/linux-release`
+  - _Generation path_: `build/linux-Release`
   - _Build options_: `--parallel 8`
   - _CMAKE options_:
     ```bash
     -DCMAKE_BUILD_TYPE=Release
-    -DCMAKE_INSTALL_PREFIX="<path to cosmoscout>/install/linux-release"
-    -DCOSMOSCOUT_EXTERNALS_DIR="<path to cosmoscout>/install/linux-externals-release"
+    -DCMAKE_INSTALL_PREFIX="<path to cosmoscout>/install/linux-Release"
+    -DCOSMOSCOUT_EXTERNALS_DIR="<path to cosmoscout>/install/linux-externals-Release"
     -DCMAKE_EXPORT_COMPILE_COMMANDS=On
     ```
 
 - Debug Profile
-  - _Generation path_: `build/linux-debug`
+  - _Generation path_: `build/linux-Debug`
   - _Build options_: `--parallel 8`
   - _CMAKE options_:
     ```
     -DCMAKE_BUILD_TYPE=Debug
-    -DCMAKE_INSTALL_PREFIX="<path to cosmoscout>/install/linux-debug"
-    -DCOSMOSCOUT_EXTERNALS_DIR="<path to cosmoscout>/install/linux-externals-release"
+    -DCMAKE_INSTALL_PREFIX="<path to cosmoscout>/install/linux-Debug"
+    -DCOSMOSCOUT_EXTERNALS_DIR="<path to cosmoscout>/install/linux-externals-Release"
     -DCMAKE_EXPORT_COMPILE_COMMANDS=On
     ```
 
 - Go to: _Run/Debug Configuration_ -> _CMake Application_ -> _cosmoscout_
 - Release profile
   - _Target_: `cosmoscout`
-  - _Executable_ -> _Select other_: `<path to cosmoscout>/install/linux-release/bin/cosmoscout`
+  - _Executable_ -> _Select other_: `<path to cosmoscout>/install/linux-Release/bin/cosmoscout`
   - _Program arguments_: `--settings=../share/config/simple_desktop.json -vista vista.ini`
-  - _Working directory_: `<path to cosmoscout>/install/linux-release/bin`
+  - _Working directory_: `<path to cosmoscout>/install/linux-Release/bin`
   - _Before launch_ -> __+__ -> _Install_
 - Debug profile
   - _Target_: `cosmoscout`
-  - _Executable_ -> _Select other_: `<path to cosmoscout>/install/linux-debug/bin/cosmoscout`
+  - _Executable_ -> _Select other_: `<path to cosmoscout>/install/linux-Debug/bin/cosmoscout`
   - _Program arguments_: `--settings=../share/config/simple_desktop.json -vista vista.ini`
-  - _Working directory_: `<path to cosmoscout>/install/linux-debug/bin`
+  - _Working directory_: `<path to cosmoscout>/install/linux-Debug/bin`
   - _Before launch_ -> __+__ -> _Install_
 
 ### Windows
@@ -80,21 +80,21 @@ highest available (and supported) version.
   - If Visual Studio is installed correctly everything else here should be set automagically.
 - Go to: _Settings_ -> _Build, Execution, Deployment_ -> _CMake_
 - Release Profile
-  - _Generation path_: `build\windows-release`
+  - _Generation path_: `build\windows-Release`
   - _Build options_: `--parallel 8`
   - _CMAKE options_:
     ```
     -DCMAKE_BUILD_TYPE=Release
     -G "Visual Studio 16 2019" -A x64
-    -DCMAKE_INSTALL_PREFIX="<path to cosmoscout>\install\windows-release"
-    -DCOSMOSCOUT_EXTERNALS_DIR="<path to cosmoscout>\install\windows-externals-release"
+    -DCMAKE_INSTALL_PREFIX="<path to cosmoscout>\install\windows-Release"
+    -DCOSMOSCOUT_EXTERNALS_DIR="<path to cosmoscout>\install\windows-externals-Release"
     ```
 
 - Go to: _Run/Debug Configuration_ -> _CMake Application_ -> _cosmoscout_
   - _Target_: `cosmoscout`
-  - _Executable_ -> _Select other_: `<path to cosmoscout>\install\windows-release\bin\cosmoscout.exe`
+  - _Executable_ -> _Select other_: `<path to cosmoscout>\install\windows-Release\bin\cosmoscout.exe`
   - _Program arguments_: `--settings=../share/config/simple_desktop.json -vista vista.ini`
-  - _Working directory_: `<path to cosmoscout>\install\windows-release\bin`
+  - _Working directory_: `<path to cosmoscout>\install\windows-Release\bin`
   - _Environment variables_: `VISTACORELIBS_DRIVER_PLUGIN_DIRS=..\lib\DriverPlugins;PATH=..\lib\;%PATH%`
     - (If you haven't set `BOOST_ROOT` as a system wide environment variable you need to add that too here.)
   - _Before launch_ -> __+__ -> _Install_
@@ -165,10 +165,10 @@ To get started with Sublime Text 3, you can create a project file in the root di
         },
         {
             "name": "Run CosmoScout VR",
-            "cmd": "install/linux-release/bin/start.sh",
+            "cmd": "install/linux-Release/bin/start.sh",
             "working_dir": "$project_path",
             "windows": {
-                "cmd": "install\\windows-release\\bin\\start.bat"
+                "cmd": "install\\windows-Release\\bin\\start.bat"
             }
         }
     ],
@@ -190,7 +190,7 @@ While this will give you a basic build system, it will not allow for auto-comple
 
 ## <img src="https://simpleicons.org/icons/visualstudio.svg" alt="Simple Icons" width=24 height=18> Visual Studio (Windows only)
 
-First, you should follow the [Generic Build Instructions](install.md) for Windows. Once CosmoScout VR has been compiled successfully, you can simply open the `cosmoscout-vr.sln` solution in either `build\windows-debug` or `build\windows-release`.
+First, you should follow the [Generic Build Instructions](install.md) for Windows. Once CosmoScout VR has been compiled successfully, you can simply open the `cosmoscout-vr.sln` solution in either `build\windows-Debug` or `build\windows-Release`.
 
 Due to the build process of CosmoScout VR, this solution can only be used for Debug or Release mode respectively. Therefore you have to select the corresponding configuration type in Visual Studio.
 
@@ -283,49 +283,49 @@ We will discuss these files in the following.
     {
       "label": "Run CosmoScout VR (Release)",
       "type": "shell",
-      "command": "install/linux-release/bin/start.sh",
+      "command": "install/linux-Release/bin/start.sh",
       "options": {
         "cwd": "${workspaceFolder}"
       },
       "problemMatcher": [],
       "windows": {
-        "command": ".\\install/windows-release/bin/start.bat"
+        "command": ".\\install/windows-Release/bin/start.bat"
       }
     },
     {
       "label": "Run CosmoScout VR (Debug)",
       "type": "shell",
-      "command": "install/linux-debug/bin/start.sh",
+      "command": "install/linux-Debug/bin/start.sh",
       "options": {
         "cwd": "${workspaceFolder}"
       },
       "problemMatcher": [],
       "windows": {
-        "command": ".\\install/windows-debug/bin/start.bat"
+        "command": ".\\install/windows-Debug/bin/start.bat"
       }
     },
     {
       "label": "Run Tests (Release)",
       "type": "shell",
-      "command": "install/linux-release/bin/run_tests.sh",
+      "command": "install/linux-Release/bin/run_tests.sh",
       "options": {
         "cwd": "${workspaceFolder}"
       },
       "problemMatcher": [],
       "windows": {
-        "command": ".\\install/windows-release/bin/run_tests.bat"
+        "command": ".\\install/windows-Release/bin/run_tests.bat"
       }
     },
     {
       "label": "Run Tests (Debug)",
       "type": "shell",
-      "command": "install/linux-debug/bin/run_tests.sh",
+      "command": "install/linux-Debug/bin/run_tests.sh",
       "options": {
         "cwd": "${workspaceFolder}"
       },
       "problemMatcher": [],
       "windows": {
-        "command": ".\\install/windows-debug/bin/run_tests.bat"
+        "command": ".\\install/windows-Debug/bin/run_tests.bat"
       }
     }
   ]
@@ -347,12 +347,12 @@ With this file in place, you can press `Ctrl+Shift+P` and select `Tasks: Run Tas
     "configurations": [
         {
             "name": "Linux",
-            "compileCommands": "${workspaceRoot}/build/linux-release/compile_commands.json",
+            "compileCommands": "${workspaceRoot}/build/linux-Release/compile_commands.json",
             "browse": {
                 "databaseFilename": "${workspaceRoot}/.vscode/browse-linux.VC.db"
             },
             "includePath": [
-                "${workspaceRoot}/build/linux-release/**"
+                "${workspaceRoot}/build/linux-Release/**"
             ],
             "defines": [],
             "cStandard": "c11",
@@ -365,8 +365,8 @@ With this file in place, you can press `Ctrl+Shift+P` and select `Tasks: Run Tas
                 "databaseFilename": "${workspaceRoot}/.vscode/browse-windows.VC.db"
             },
             "includePath": [
-                "${workspaceRoot}/build/windows-release/**",
-                "${workspaceRoot}/install/windows-externals-release/include"
+                "${workspaceRoot}/build/windows-Release/**",
+                "${workspaceRoot}/install/windows-externals-Release/include"
             ],
             "defines": [],
             "cStandard": "c11",
@@ -389,13 +389,13 @@ This file configures Intellisense. On Linux, the CMake flag `-DCMAKE_EXPORT_COMP
       "name": "Debugger (Linux)",
       "type": "cppdbg",
       "request": "launch",
-      "program": "${workspaceFolder}/install/linux-debug/bin/cosmoscout",
+      "program": "${workspaceFolder}/install/linux-Debug/bin/cosmoscout",
       "args": [
         "--settings=../share/config/simple_desktop.json",
         "-vistaini vista.ini"
       ],
       "stopAtEntry": false,
-      "cwd": "${workspaceFolder}/install/linux-debug/bin",
+      "cwd": "${workspaceFolder}/install/linux-Debug/bin",
       "environment": [
         {
           "name": "VISTACORELIBS_DRIVER_PLUGIN_DIRS",
@@ -420,13 +420,13 @@ This file configures Intellisense. On Linux, the CMake flag `-DCMAKE_EXPORT_COMP
       "name": "Debugger (Windows)",
       "type": "cppvsdbg",
       "request": "launch",
-      "program": "${workspaceFolder}/install/windows-debug/bin/cosmoscout",
+      "program": "${workspaceFolder}/install/windows-Debug/bin/cosmoscout",
       "args": [
         "--settings=../share/config/simple_desktop.json",
         "-vistaini vista.ini"
       ],
       "stopAtEntry": false,
-      "cwd": "${workspaceFolder}/install/windows-debug/bin",
+      "cwd": "${workspaceFolder}/install/windows-Debug/bin",
       "environment": [
         {
           "name": "VISTACORELIBS_DRIVER_PLUGIN_DIRS",

--- a/docs/install.md
+++ b/docs/install.md
@@ -57,12 +57,12 @@ git submodule update --init
 ./make_externals.sh -G "Unix Makefiles"
 ```
 
-This will clone the repository to `cosmoscout-vr` configure and build all externals in `cosmoscout-vr/build/linux-externals-release` and will install them to `cosmoscout-vr/install/linux-externals-release`.
+This will clone the repository to `cosmoscout-vr` configure and build all externals in `cosmoscout-vr/build/linux-externals-Release` and will install them to `cosmoscout-vr/install/linux-externals-Release`.
 All parameters given to `make_externals.bat` will be forwarded to CMake. For example, you can change the CMake generator this way.
 
 ### Compiling CosmoScout VR
 
-This will configure and build CosmoScout VR in `cosmoscout-vr/build/linux-release` and will install it to `cosmoscout-vr/install/linux-release`.
+This will configure and build CosmoScout VR in `cosmoscout-vr/build/linux-Release` and will install it to `cosmoscout-vr/install/linux-Release`.
 Again, all parameters given to `make.sh` will be forwarded to CMake:
 
 ```shell
@@ -73,7 +73,7 @@ Again, all parameters given to `make.sh` will be forwarded to CMake:
 The application can be executed with:
 
 ```shell
-./install/linux-release/bin/start.sh
+./install/linux-Release/bin/start.sh
 ```
 
 When started for the very first time, some example datasets will be downloaded from the internet.
@@ -83,8 +83,8 @@ The progress of this operation is shown on the loading screen.
 Since you specified `-DCOSMOSCOUT_UNIT_TESTS=On` at build time, you can now execute the unit tests with (the _graphical tests_ require [Xvfb](https://en.wikipedia.org/wiki/Xvfb) and [imagemagick](https://imagemagick.org/index.php) to be installed on your system. On Ubuntu: `sudo apt-get install xvfb imagemagick`):
 
 ```shell
-./install/linux-release/bin/run_tests.sh
-./install/linux-release/bin/run_graphical_tests.sh
+./install/linux-Release/bin/run_tests.sh
+./install/linux-Release/bin/run_graphical_tests.sh
 ```
 
 :information_source: _**Tip:** If you wish, you can delete the directories `build` and `install` at any time in order to force a complete reconfiguration or re-installation._
@@ -146,7 +146,7 @@ git submodule update --init
 make_externals.bat -G "Visual Studio 15 Win64"
 ```
 
-This will clone the repository to `cosmoscout-vr` configure and build all externals in `cosmoscout-vr\build\windows-externals-release` and will install them to `cosmoscout-vr\install\windows-externals-release`.
+This will clone the repository to `cosmoscout-vr` configure and build all externals in `cosmoscout-vr\build\windows-externals-Release` and will install them to `cosmoscout-vr\install\windows-externals-Release`.
 All parameters given to `make_externals.bat` will be forwarded to CMake. For example, you can change the CMake generator this way.
 
 ### Compiling CosmoScout VR
@@ -159,11 +159,11 @@ set BOOST_ROOT=C:\local\boost_1_69_0
 make.bat -G "Visual Studio 15 Win64" -DCOSMOSCOUT_UNIT_TESTS=On
 ```
 
-This will configure and build CosmoScout VR in `cosmoscout-vr\build\windows-release` and will install it to `cosmoscout-vr\install\windows-release`.
+This will configure and build CosmoScout VR in `cosmoscout-vr\build\windows-Release` and will install it to `cosmoscout-vr\install\windows-Release`.
 The application can be executed with:
 
 ```batch
-cd install\windows-release\bin
+cd install\windows-Release\bin
 start.bat
 ```
 
@@ -174,7 +174,7 @@ The progress of this operation is shown on the loading screen.
 Since you specified `-DCOSMOSCOUT_UNIT_TESTS=On` at build time, you can now execute the unit tests with:
 
 ```batch
-install\linux-release\bin\run_tests.bat
+install\linux-Release\bin\run_tests.bat
 ```
 
 :information_source: _**Tip:** If you wish, you can delete the directories `build` and `install` at any time in order to force a complete reconfiguration or re-installation._

--- a/lcov.sh
+++ b/lcov.sh
@@ -24,9 +24,9 @@ SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
 cd $SCRIPT_DIR
 
 # Check if ComoScout VR debug build is enabled with "export COSMOSCOUT_DEBUG_BUILD=true".
-BUILD_TYPE=release
+BUILD_TYPE=Release
 case "$COSMOSCOUT_DEBUG_BUILD" in
-  (true) echo "CosmoScout VR debug build is enabled!"; BUILD_TYPE=debug;
+  (true) echo "CosmoScout VR debug build is enabled!"; BUILD_TYPE=Debug;
 esac
 
 # Get the current directory - this should contain the build and install directory.

--- a/make.bat
+++ b/make.bat
@@ -26,12 +26,12 @@ IF NOT "%~1"=="" (
   SET CMAKE_FLAGS=%*
 )
 
-rem Check if ComoScout VR debug build is set with the environment variable
+rem Check if ComoScout VR Debug build is set with the environment variable
 IF "%COSMOSCOUT_DEBUG_BUILD%"=="true" (
   ECHO CosmoScout VR debug build is enabled!
-  set BUILD_TYPE=debug
+  set BUILD_TYPE=Debug
 ) else (
-  set BUILD_TYPE=release
+  set BUILD_TYPE=Release
 )
 
 rem This directory should contain the top-level CMakeLists.txt - it is assumed to reside in the same

--- a/make.sh
+++ b/make.sh
@@ -30,9 +30,9 @@ if [ $# -ne 0 ]; then
 fi
 
 # Check if ComoScout VR debug build is enabled with "export COSMOSCOUT_DEBUG_BUILD=true".
-BUILD_TYPE=release
+BUILD_TYPE=Release
 case "$COSMOSCOUT_DEBUG_BUILD" in
-  (true) echo "CosmoScout VR debug build is enabled!"; BUILD_TYPE=debug;
+  (true) echo "CosmoScout VR debug build is enabled!"; BUILD_TYPE=Debug;
 esac
 
 # This directory should contain the top-level CMakeLists.txt - it is assumed to reside in the same

--- a/make_externals.bat
+++ b/make_externals.bat
@@ -36,9 +36,9 @@ IF NOT errorlevel 1 (
 rem Check if ComoScout VR debug build is enabled with "set COSMOSCOUT_DEBUG_BUILD=true".
 IF "%COSMOSCOUT_DEBUG_BUILD%"=="true" (
   echo CosmoScout VR debug build is enabled!
-  set BUILD_TYPE=debug
+  set BUILD_TYPE=Debug
 ) else (
-  set BUILD_TYPE=release
+  set BUILD_TYPE=Release
 )
 
 rem Check if unity build is disabled with "set COSMOSCOUT_NO_UNITY_BUILD=true".

--- a/make_externals.sh
+++ b/make_externals.sh
@@ -31,9 +31,9 @@ if [ $# -ne 0 ]; then
 fi
 
 # Check if ComoScout VR debug build is enabled with "export COSMOSCOUT_DEBUG_BUILD=true".
-BUILD_TYPE=release
+BUILD_TYPE=Release
 case "$COSMOSCOUT_DEBUG_BUILD" in
-  (true) echo "CosmoScout VR debug build is enabled!"; BUILD_TYPE=debug;
+  (true) echo "CosmoScout VR debug build is enabled!"; BUILD_TYPE=Debug;
 esac
 
 # Check if unity build is disabled with "export COSMOSCOUT_NO_UNITY_BUILD=true".


### PR DESCRIPTION
Capitalize build types names. I did this to simplify integration of the vscode-cmake-tools addon in my vscode setup.