### PR TITLE
Consistent logger names

### DIFF
--- a/plugins/csp-anchor-labels/src/logger.cpp
+++ b/plugins/csp-anchor-labels/src/logger.cpp
@@ -13,7 +13,7 @@ namespace csp::anchorlabels {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 spdlog::logger& logger() {
-  static auto logger = cs::utils::createLogger("csp-anchorlabels");
+  static auto logger = cs::utils::createLogger("csp-anchor-labels");
   return *logger;
 }
 

--- a/plugins/csp-anchor-labels/src/logger.hpp
+++ b/plugins/csp-anchor-labels/src/logger.hpp
@@ -11,7 +11,7 @@
 
 namespace csp::anchorlabels {
 
-/// This creates the default singleton logger for "csp-anchorlabels" when called for the first time
+/// This creates the default singleton logger for "csp-anchor-labels" when called for the first time
 /// and returns it. See cs-utils/logger.hpp for more logging details.
 spdlog::logger& logger();
 

--- a/plugins/csp-fly-to-locations/src/logger.hpp
+++ b/plugins/csp-fly-to-locations/src/logger.hpp
@@ -11,7 +11,7 @@
 
 namespace csp::flytolocations {
 
-/// This creates the default singleton logger for "csp-flytolocations" when called for the first
+/// This creates the default singleton logger for "csp-fly-to-locations" when called for the first
 /// time and returns it. See cs-utils/logger.hpp for more logging details.
 spdlog::logger& logger();
 

--- a/plugins/csp-lod-bodies/src/logger.cpp
+++ b/plugins/csp-lod-bodies/src/logger.cpp
@@ -13,7 +13,7 @@ namespace csp::lodbodies {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 spdlog::logger& logger() {
-  static auto logger = cs::utils::createLogger("csp-lodbodies");
+  static auto logger = cs::utils::createLogger("csp-lod-bodies");
   return *logger;
 }
 

--- a/plugins/csp-lod-bodies/src/logger.hpp
+++ b/plugins/csp-lod-bodies/src/logger.hpp
@@ -11,7 +11,7 @@
 
 namespace csp::lodbodies {
 
-/// This creates the default singleton logger for "csp-lodbodies" when called for the first time
+/// This creates the default singleton logger for "csp-lod-bodies" when called for the first time
 /// and returns it. See cs-utils/logger.hpp for more logging details.
 spdlog::logger& logger();
 

--- a/plugins/csp-measurement-tools/src/logger.cpp
+++ b/plugins/csp-measurement-tools/src/logger.cpp
@@ -13,7 +13,7 @@ namespace csp::measurementtools {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 spdlog::logger& logger() {
-  static auto logger = cs::utils::createLogger("csp-measurementtools");
+  static auto logger = cs::utils::createLogger("csp-measurement-tools");
   return *logger;
 }
 

--- a/plugins/csp-measurement-tools/src/logger.hpp
+++ b/plugins/csp-measurement-tools/src/logger.hpp
@@ -11,7 +11,7 @@
 
 namespace csp::measurementtools {
 
-/// This creates the default singleton logger for "csp-measurementtools" when called for the first
+/// This creates the default singleton logger for "csp-measurement-tools" when called for the first
 /// time and returns it. See cs-utils/logger.hpp for more logging details.
 spdlog::logger& logger();
 

--- a/plugins/csp-simple-bodies/src/logger.cpp
+++ b/plugins/csp-simple-bodies/src/logger.cpp
@@ -13,7 +13,7 @@ namespace csp::simplebodies {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 spdlog::logger& logger() {
-  static auto logger = cs::utils::createLogger("csp-simplebodies");
+  static auto logger = cs::utils::createLogger("csp-simple-bodies");
   return *logger;
 }
 

--- a/plugins/csp-simple-bodies/src/logger.hpp
+++ b/plugins/csp-simple-bodies/src/logger.hpp
@@ -11,7 +11,7 @@
 
 namespace csp::simplebodies {
 
-/// This creates the default singleton logger for "csp-simplebodies" when called for the first time
+/// This creates the default singleton logger for "csp-simple-bodies" when called for the first time
 /// and returns it. See cs-utils/logger.hpp for more logging details.
 spdlog::logger& logger();
 


### PR DESCRIPTION
This makes our logger names more consistent. They now should always use the plugin name.