### PR TITLE
LOD body fixes

### DIFF
--- a/plugins/csp-lod-bodies/README.md
+++ b/plugins/csp-lod-bodies/README.md
@@ -23,6 +23,7 @@ This plugin can be enabled with the following configuration in your `settings.js
               "copyright": <string>, // The copyright holder of the data set (also shown in the UI).
               "format": <string>,    // "Float32", "UInt8" or "U8Vec3".
               "url": <string>,       // The URL of the mapserver including the "SERVICE=wms" parameter.
+                                     // Use "offline" to only use cached data for this dataset.
               "layers": <string>,    // A comma,seperated list of WMS layers.
               "maxLevel": <int>      // The maximum quadtree depth to load.
             },
@@ -33,6 +34,7 @@ This plugin can be enabled with the following configuration in your `settings.js
               "copyright": <string>, // The copyright holder of the data set (also shown in the UI).
               "format": <string>,    // "Float32", "UInt8" or "U8Vec3".
               "url": <string>,       // The URL of the mapserver including the "SERVICE=wms" parameter.
+                                     // Use "offline" to only use cached data for this dataset.
               "layers": <string>,    // A comma,seperated list of WMS layers.
               "maxLevel": <int>      // The maximum quadtree depth to load.
             },

--- a/plugins/csp-lod-bodies/shaders/VistaPlanetTerrainShaderFunctions.frag
+++ b/plugins/csp-lod-bodies/shaders/VistaPlanetTerrainShaderFunctions.frag
@@ -33,7 +33,7 @@ float VP_getShadow(vec3 position)
 
     if (cascade < 0)
     {
-        return 1;
+        return 1.0;
     }
 
     vec3 coords = VP_getShadowMapCoords(cascade, position);
@@ -44,10 +44,16 @@ float VP_getShadow(vec3 position)
     for(int x=-1; x<=1; x++){
         for(int y=-1; y<=1; y++){
             vec2 off = vec2(x,y)*size;
-            shadow += texture(VP_shadowMaps[cascade], coords - vec3(off, VP_shadowBias * (cascade+1)));
+
+            // Dynamic array lookups are not supported in OpenGL 3.3
+            if      (cascade == 0) shadow += texture(VP_shadowMaps[0], coords - vec3(off, VP_shadowBias * 1));
+            else if (cascade == 1) shadow += texture(VP_shadowMaps[1], coords - vec3(off, VP_shadowBias * 2));
+            else if (cascade == 2) shadow += texture(VP_shadowMaps[2], coords - vec3(off, VP_shadowBias * 3));
+            else if (cascade == 3) shadow += texture(VP_shadowMaps[3], coords - vec3(off, VP_shadowBias * 4));
+            else                   shadow += texture(VP_shadowMaps[4], coords - vec3(off, VP_shadowBias * 5));
         }
     }
 
-    return shadow / 9;
+    return shadow / 9.0;
 }
 

--- a/plugins/csp-lod-bodies/src/TileSourceWebMapService.cpp
+++ b/plugins/csp-lod-bodies/src/TileSourceWebMapService.cpp
@@ -55,7 +55,7 @@ bool loadImpl(
     return false;
   }
 
-  // Data is not available. That's most likely do to our server being offline.
+  // Data is not available. That's most likely due to our server being offline.
   if (!cacheFile) {
     return false;
   }

--- a/plugins/csp-lod-bodies/src/TileSourceWebMapService.hpp
+++ b/plugins/csp-lod-bodies/src/TileSourceWebMapService.hpp
@@ -12,6 +12,7 @@
 #include "TileSource.hpp"
 
 #include <cstdio>
+#include <optional>
 #include <string>
 
 namespace csp::lodbodies {
@@ -60,7 +61,14 @@ class TileSourceWebMapService : public TileSource {
   /// These can be used to pre-populate the local cache, returns true if the tile is on the diagonal
   /// of base patch 4 (the one which is cut in two halves).
   static bool getXY(int level, glm::int64 patchIdx, int& x, int& y);
-  std::string loadData(int level, int x, int y);
+
+  // This downloads the tile with the given coordinates from the MapServer. It is stored in the
+  // local map cache and the resulting file name is returned. If the tile is already present in the
+  // map cache, no request is made and the cahce file name is returned immediately. It may happen
+  // that a tile cannot be downloaded (e.g. if the server is offline) - in this case no error is
+  // thrown but std::nullopt is returned. In several other cases (e.g. cache directory is not
+  // writable) a std::runtime_error is thrown.
+  std::optional<std::string> loadData(int level, int x, int y);
 
  private:
   static std::mutex mTileSystemMutex;


### PR DESCRIPTION
This adds the following:
* `"url": "offline"` can now be used to prevent a `TileSourceWebMapService` from accessing a map server. Only cached data will be used.
* The terrain shader works with OpenGL 3.3.
* If loading of a cached tile fails, it will be removed now effectively triggering a re-download.
* `csp-lod-bodies` will now only print errors for critical events. If downloading a tile failed, this not considered critical.
* The slope-range and height-range slider now work as supposed.