### PR TITLE
Add some includes for gcc 10.2.0

### DIFF
--- a/src/cs-graphics/HDRBuffer.hpp
+++ b/src/cs-graphics/HDRBuffer.hpp
@@ -10,6 +10,7 @@
 #include "cs_graphics_export.hpp"
 
 #include <array>
+#include <cstdint>
 #include <unordered_map>
 #include <vector>
 

--- a/src/cs-gui/types.hpp
+++ b/src/cs-gui/types.hpp
@@ -11,6 +11,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <string>
 #include <variant>
 #include <vector>
 


### PR DESCRIPTION
With this, CosmoScout VR compiles fine for me on Ubuntu 20.04 with gcc 9.3.0, 10.0.1 and 10.2.0. This should resolve #185.

