### PR TITLE
Fix SPICE crash

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -112,7 +112,7 @@ Last but not least, the far clipping plane depends on the scene scale: Near clip
     ...
   }
   ```
-  Now if you want to attach a simple body or a trajectory to this anchor, the configuration of the respective plugins will only refer to `"Moon"`. `"center"` and `"frame"` define the SPICE reference frame, `"startExistence"` and `"endExistence"` should match the data coverage of your SPICE kernels.
+  Now if you want to attach a simple body or a trajectory to this anchor, the configuration of the respective plugins will only refer to `"Moon"`. `"center"` and `"frame"` define the SPICE reference frame, `"startExistence"` and `"endExistence"` should match the data coverage of your SPICE kernels. Keep in mind, that the dates are given UTC, your SPICE kernel's coverage is however most likely given in TDB.
 * **`"events"`:** This list may contain events which will be shown on the timeline. Take this as an example:
   ```javascript
   "events": [

--- a/plugins/csp-trajectories/src/Trajectory.cpp
+++ b/plugins/csp-trajectories/src/Trajectory.cpp
@@ -64,9 +64,8 @@ void Trajectory::update(double tTime, cs::scene::CelestialObserver const& oObs) 
   cs::scene::CelestialObject::update(tTime, oObs);
 
   double dLengthSeconds = pLength.get() * 24.0 * 60.0 * 60.0;
-  mTrailIsInExistence   = (tTime > mStartExistence && tTime < mEndExistence + dLengthSeconds);
 
-  if (mPluginSettings->mEnableTrajectories.get() && mTrailIsInExistence) {
+  if (mPluginSettings->mEnableTrajectories.get() && getIsInExistence()) {
     double dSampleLength = dLengthSeconds / pSamples.get();
 
     cs::scene::CelestialAnchor target(mTargetCenter, mTargetFrame);
@@ -198,7 +197,7 @@ void Trajectory::setFrameName(std::string const& sFrameName) {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 bool Trajectory::Do() {
-  if (mPluginSettings->mEnableTrajectories.get() && pVisible.get() && mTrailIsInExistence) {
+  if (mPluginSettings->mEnableTrajectories.get() && pVisible.get() && getIsInExistence()) {
     cs::utils::FrameTimings::ScopedTimer timer("Trajectories");
     mTrajectory.Do();
   }

--- a/plugins/csp-trajectories/src/Trajectory.hpp
+++ b/plugins/csp-trajectories/src/Trajectory.hpp
@@ -71,8 +71,6 @@ class Trajectory : public cs::scene::CelestialObject, public IVistaOpenGLDraw {
   double                  mLastSampleTime{};
   double                  mLastUpdateTime;
   double                  mLastFrameTime{};
-
-  bool mTrailIsInExistence = false;
 };
 
 } // namespace csp::trajectories


### PR DESCRIPTION
This fixes issue #102 by not attempting to draw a trajectory when the target body is not in existence.

This PR also updates Vista to the current develop branch.