### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,9 +166,13 @@ jobs:
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
           -DCOSMOSCOUT_UNIT_TESTS=On -DBOOST_ROOT=$BOOST_ROOT_1_72_0 -DBoost_ARCHITECTURE=-x64
       - name: Run Tests
-        run: ./install/linux-Release/bin/run_tests.sh
+        run: >
+          export LD_LIBRARY_PATH="$BOOST_ROOT_1_72_0/lib:$LD_LIBRARY_PATH"
+          ./install/linux-Release/bin/run_tests.sh
       - name: Run Graphical Tests
-        run: ./install/linux-Release/bin/run_graphical_tests.sh
+        run: >
+          export LD_LIBRARY_PATH="$BOOST_ROOT_1_72_0/lib:$LD_LIBRARY_PATH"
+          ./install/linux-Release/bin/run_graphical_tests.sh
       - name: Upload Results of Failed Test
         uses: actions/upload-artifact@v1
         if: failure()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -219,6 +219,8 @@ jobs:
           -DCOSMOSCOUT_UNIT_TESTS=On -DBOOST_ROOT=%BOOST_ROOT_1_72_0%
       - name: Run Tests
         shell: cmd
-        run: install\\windows-Release\\bin\\run_tests.bat
+        run: >
+          SET PATH=%BOOST_ROOT_1_72_0%\\lib;%PATH%
+          install\\windows-Release\\bin\\run_tests.bat
       - name: Print clcache Statistics
         run: clcache -s

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,7 +119,9 @@ jobs:
           name: graphical-test-results-gcc
           path: install/linux-Release/bin/test
       - name: Calculate Test Coverage
-        run: ./lcov.sh
+        run: |
+          export LD_LIBRARY_PATH="$BOOST_ROOT_1_72_0/lib:$LD_LIBRARY_PATH"
+          ./lcov.sh
       - name: Upload Coverage Info
         uses: coverallsapp/github-action@master
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,9 +105,13 @@ jobs:
           -DCOSMOSCOUT_COVERAGE_INFO=On -DCOSMOSCOUT_UNIT_TESTS=On
           -DBOOST_ROOT=$BOOST_ROOT_1_72_0 -DBoost_ARCHITECTURE=-x64
       - name: Run Tests
-        run: ./install/linux-Release/bin/run_tests.sh
+        run: |
+          export LD_LIBRARY_PATH="$BOOST_ROOT_1_72_0/lib:$LD_LIBRARY_PATH"
+          ./install/linux-Release/bin/run_tests.sh
       - name: Run Graphical Tests
-        run: ./install/linux-Release/bin/run_graphical_tests.sh
+        run: |
+          export LD_LIBRARY_PATH="$BOOST_ROOT_1_72_0/lib:$LD_LIBRARY_PATH"
+          ./install/linux-Release/bin/run_graphical_tests.sh
       - name: Upload Results of Failed Test
         uses: actions/upload-artifact@v1
         if: failure()
@@ -166,11 +170,11 @@ jobs:
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
           -DCOSMOSCOUT_UNIT_TESTS=On -DBOOST_ROOT=$BOOST_ROOT_1_72_0 -DBoost_ARCHITECTURE=-x64
       - name: Run Tests
-        run: >
+        run: |
           export LD_LIBRARY_PATH="$BOOST_ROOT_1_72_0/lib:$LD_LIBRARY_PATH"
           ./install/linux-Release/bin/run_tests.sh
       - name: Run Graphical Tests
-        run: >
+        run: |
           export LD_LIBRARY_PATH="$BOOST_ROOT_1_72_0/lib:$LD_LIBRARY_PATH"
           ./install/linux-Release/bin/run_graphical_tests.sh
       - name: Upload Results of Failed Test
@@ -219,7 +223,7 @@ jobs:
           -DCOSMOSCOUT_UNIT_TESTS=On -DBOOST_ROOT=%BOOST_ROOT_1_72_0%
       - name: Run Tests
         shell: cmd
-        run: >
+        run: |
           SET PATH=%BOOST_ROOT_1_72_0%\\lib;%PATH%
           install\\windows-Release\\bin\\run_tests.bat
       - name: Print clcache Statistics


### PR DESCRIPTION
GitHub has removed Boost from the `$LD_LIBRARY_PATH` and from the  `%PATH%`. Hence, all of out tests failed. Now it should be working again.