### PR TITLE
Faster loading of stars on initial startup

### DIFF
--- a/plugins/csp-stars/src/Stars.cpp
+++ b/plugins/csp-stars/src/Stars.cpp
@@ -493,15 +493,8 @@ bool Stars::readStarsFromCatalog(CatalogType type, std::string const& filename) 
       getline(file, line);
 
       // parse line:
-      // separate complete items consisting of "val0|val1|...|valN|" into vector of value
-      // strings
-      std::stringstream        stream(line);
-      std::string              item;
-      std::vector<std::string> items;
-
-      while (getline(stream, item, '|')) {
-        items.emplace_back(item);
-      }
+      // separate complete items consisting of "val0|val1|...|valN|" into vector of value strings
+      std::vector<std::string> items = cs::utils::splitString(line, '|');
 
       // convert value strings to int/double/float and save in star data structure
       // expecting Hipparcos or Tycho-1 catalog and more than 12 columns

--- a/src/cs-utils/utils.cpp
+++ b/src/cs-utils/utils.cpp
@@ -89,16 +89,23 @@ std::string toString(char const* v) {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 std::vector<std::string> splitString(std::string const& s, char delim) {
-  std::vector<std::string> elems;
+  size_t start = 0;
+  size_t end   = s.find_first_of(delim);
 
-  std::stringstream ss(s);
-  std::string       item;
+  std::vector<std::string> output;
 
-  while (std::getline(ss, item, delim)) {
-    elems.push_back(item);
+  while (end <= std::string::npos) {
+    output.emplace_back(s.substr(start, end - start));
+
+    if (end == std::string::npos) {
+      break;
+    }
+
+    start = end + 1;
+    end   = s.find_first_of(delim, start);
   }
 
-  return elems;
+  return output;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Replaced the string split method in utils with a faster one. The stars plugin now makes use of it. It reduced inital loading times from 20 to 15 seconds.