### PR TITLE
Fix inverted light shaft condition

### DIFF
--- a/plugins/csp-atmospheres/src/Plugin.cpp
+++ b/plugins/csp-atmospheres/src/Plugin.cpp
@@ -143,10 +143,9 @@ void Plugin::init() {
   mPluginSettings->mWaterLevel.connectAndTouch(
       [this](float value) { mGuiManager->setSliderValue("atmosphere.setWaterLevel", value); });
 
-  mEnableShadowsConnection = mAllSettings->mGraphics.pEnableShadows.connect([this](bool /*val*/) {
+  mEnableShadowsConnection = mAllSettings->mGraphics.pEnableShadows.connect([this](bool value) {
     for (auto const& atmosphere : mAtmospheres) {
-      if (mAllSettings->mGraphics.pEnableShadows.get() &&
-          mPluginSettings->mEnableLightShafts.get()) {
+      if (value && mPluginSettings->mEnableLightShafts.get()) {
         atmosphere.second->getRenderer().setShadowMap(mGraphicsEngine->getShadowMap());
       } else {
         atmosphere.second->getRenderer().setShadowMap(nullptr);
@@ -175,10 +174,9 @@ void Plugin::init() {
         }
       });
 
-  mPluginSettings->mEnableLightShafts.connect([this](bool /*val*/) {
+  mPluginSettings->mEnableLightShafts.connect([this](bool value) {
     for (auto const& atmosphere : mAtmospheres) {
-      if (mAllSettings->mGraphics.pEnableShadows.get() &&
-          mPluginSettings->mEnableLightShafts.get()) {
+      if (mAllSettings->mGraphics.pEnableShadows.get() && value) {
         atmosphere.second->getRenderer().setShadowMap(mGraphicsEngine->getShadowMap());
       } else {
         atmosphere.second->getRenderer().setShadowMap(nullptr);


### PR DESCRIPTION
The enable-light-shafts-checkbox of the `csp-atmospheres` plugin behaved like it was inverted. The reason was that the `onChange` signals get emitted _before_ the internal value is changed.