### PR TITLE
Fix luminance calculation for the Sun

### DIFF
--- a/plugins/csp-simple-bodies/src/SimpleBody.cpp
+++ b/plugins/csp-simple-bodies/src/SimpleBody.cpp
@@ -299,9 +299,19 @@ bool SimpleBody::Do() {
     // If the SimpleBody is actually the sun, we have to calculate the lighting differently.
     if (mSettings->mGraphics.pEnableHDR.get()) {
       double sceneScale = 1.0 / mSolarSystem->getObserver().getAnchorScale();
-      sunIlluminance    = static_cast<float>(
+
+      // To get the luminous exitance (in lux) of the Sun, we have to divide its luminous power (in
+      // lumens) by its surface area.
+      double luminousExitance =
           mSolarSystem->pSunLuminousPower.get() /
-          (sceneScale * sceneScale * mRadii[0] * mRadii[0] * 4.0 * glm::pi<double>()));
+          (sceneScale * sceneScale * mRadii[0] * mRadii[0] * 4.0 * glm::pi<double>());
+
+      // We consider the Sun to emit light equally in all directions. So we have to divide the
+      // luminous exitance by PI to get actual luminance values.
+      double sunLuminance = luminousExitance / glm::pi<double>();
+
+      // The variable is called illuminance, for the sun it contains actually luminance values.
+      sunIlluminance = static_cast<float>(sunLuminance);
     }
 
     ambientBrightness = 1.0F;

--- a/src/cs-core/SolarSystem.cpp
+++ b/src/cs-core/SolarSystem.cpp
@@ -208,15 +208,10 @@ void SolarSystem::update() {
   // the average distance of Earth with the surface area of a sphere with a radius of the average
   // distance of Earth.
 
-  // Sun's illuminance in lux at Earth.
-  double const sunIlluminanceAtEarth = 1.1e5;
-
-  // Average distance between Sun and Earth in meters.
-  double const distEarthSun = 1.496e11;
-
-  // Luminous power of the Sun in lumens.
-  double const sunLuminousPower =
-      4.0 * glm::pi<double>() * distEarthSun * distEarthSun * sunIlluminanceAtEarth;
+  // Luminous power of the Sun in lumens. Number is taken from
+  // Darula, Stan, Richard Kittler, and Christian A. Gueymard. "Reference luminous solar constant
+  // and solar luminance for illuminance calculations." Solar Energy 79.5 (2005)
+  double const sunLuminousPower = 3.75e28;
 
   // As our scene is always scaled, we have to scale the luminous power of the sun accordingly.
   // Else, our Sun would be extremely bright when scaled down.


### PR DESCRIPTION
After studying [_"Reference luminous solar constant and solar luminance for illuminance calculations." by Darula, Stan, Richard Kittler, and Christian A. Gueymard_](http://www.academia.edu/download/50238350/Reference_luminous_solar_constant_and_so20161110-7287-1ipdcez.pdf), I realized that our luminance calculation for the Sun was still not right. This should fix it now.