### PR TITLE
Fix energy conservation in shading

### DIFF
--- a/plugins/csp-atmospheres/src/Shaders.cpp
+++ b/plugins/csp-atmospheres/src/Shaders.cpp
@@ -626,9 +626,9 @@ const char* AtmosphereRenderer::cAtmosphereFrag1 = R"(
       // add clouds themselves
       #if USE_CLOUDMAP
         #if ENABLE_HDR
-          oColor += cloudColor.rgb * (1 - uAmbientBrightness);
+          oColor += cloudColor.rgb * (1 - uAmbientBrightness) * 0.3;
         #else
-          // For non-hdr rendering, the clouds need to be darkend a little.
+          // For non-hdr rendering, the clouds need to be darkend a little more.
           oColor += cloudColor.rgb * (1 - uAmbientBrightness) * 0.1;
         #endif
       #endif

--- a/plugins/csp-lod-bodies/shaders/Planet.frag
+++ b/plugins/csp-lod-bodies/shaders/Planet.frag
@@ -111,6 +111,11 @@ void main()
 
   fragColor = fragColor * uSunDirIlluminance.w;
 
+  #if $ENABLE_HDR
+    // energy conservation for lambertian reflectance
+    fragColor /= VP_PI;
+  #endif
+
   float directLight = 1.0;
   float ambientLight = ambientBrightness;
 

--- a/plugins/csp-rings/src/Ring.cpp
+++ b/plugins/csp-rings/src/Ring.cpp
@@ -122,7 +122,7 @@ Ring::Ring(std::shared_ptr<cs::core::Settings> settings,
   mSphereVAO.SpecifyAttributeArrayFloat(
       0, 2, GL_FLOAT, GL_FALSE, sizeof(glm::vec2), 0, &mSphereVBO);
 
-  // Recreate the shader if HDR rendering mode are toggled.
+  // Recreate the shader if HDR rendering mode is toggled.
   mEnableHDRConnection =
       mSettings->mGraphics.pEnableHDR.connect([this](bool /*enabled*/) { mShaderDirty = true; });
 

--- a/plugins/csp-rings/src/Ring.cpp
+++ b/plugins/csp-rings/src/Ring.cpp
@@ -32,8 +32,6 @@ const size_t GRID_RESOLUTION = 200;
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 const char* Ring::SPHERE_VERT = R"(
-#version 330
-
 uniform vec3 uSunDirection;
 uniform vec2 uRadii;
 uniform mat4 uMatModelView;
@@ -63,8 +61,6 @@ void main()
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 const char* Ring::SPHERE_FRAG = R"(
-#version 330
-
 uniform sampler2D uSurfaceTexture;
 uniform float uSunIlluminance;
 uniform float uFarClip;
@@ -77,10 +73,24 @@ in vec3 vPosition;
 // outputs
 layout(location = 0) out vec4 oColor;
 
+const float M_PI = 3.141592653589793;
+
+vec3 SRGBtoLINEAR(vec3 srgbIn)
+{
+  vec3 bLess = step(vec3(0.04045),srgbIn);
+  return mix( srgbIn/vec3(12.92), pow((srgbIn+vec3(0.055))/vec3(1.055),vec3(2.4)), bLess );
+}
+
 void main()
 {
     oColor = texture(uSurfaceTexture, vTexCoords);
-    oColor.rgb *= uSunIlluminance;
+
+    #ifdef ENABLE_HDR
+      oColor.rgb = SRGBtoLINEAR(oColor.rgb) * uSunIlluminance / M_PI;
+    #else
+      oColor.rgb = oColor.rgb * uSunIlluminance;
+    #endif
+
     gl_FragDepth = length(vPosition) / uFarClip;
 }
 )";
@@ -112,17 +122,9 @@ Ring::Ring(std::shared_ptr<cs::core::Settings> settings,
   mSphereVAO.SpecifyAttributeArrayFloat(
       0, 2, GL_FLOAT, GL_FALSE, sizeof(glm::vec2), 0, &mSphereVBO);
 
-  // Create sphere shader.
-  mShader.InitVertexShaderFromString(SPHERE_VERT);
-  mShader.InitFragmentShaderFromString(SPHERE_FRAG);
-  mShader.Link();
-
-  mUniforms.modelViewMatrix  = mShader.GetUniformLocation("uMatModelView");
-  mUniforms.projectionMatrix = mShader.GetUniformLocation("uMatProjection");
-  mUniforms.surfaceTexture   = mShader.GetUniformLocation("uSurfaceTexture");
-  mUniforms.radii            = mShader.GetUniformLocation("uRadii");
-  mUniforms.farClip          = mShader.GetUniformLocation("uFarClip");
-  mUniforms.sunIlluminance   = mShader.GetUniformLocation("uSunIlluminance");
+  // Recreate the shader if HDR rendering mode are toggled.
+  mEnableHDRConnection =
+      mSettings->mGraphics.pEnableHDR.connect([this](bool /*enabled*/) { mShaderDirty = true; });
 
   // Add to scenegraph.
   VistaSceneGraph* pSG = GetVistaSystem()->GetGraphicsManager()->GetSceneGraph();
@@ -134,6 +136,8 @@ Ring::Ring(std::shared_ptr<cs::core::Settings> settings,
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 Ring::~Ring() {
+  mSettings->mGraphics.pEnableHDR.disconnect(mEnableHDRConnection);
+
   VistaSceneGraph* pSG = GetVistaSystem()->GetGraphicsManager()->GetSceneGraph();
   pSG->GetRoot()->DisconnectChild(mGLNode.get());
 }
@@ -164,6 +168,30 @@ bool Ring::Do() {
   }
 
   cs::utils::FrameTimings::ScopedTimer timer("Rings");
+
+  // (Re-)Create ring shader if necessary.
+  if (mShaderDirty) {
+    mShader = VistaGLSLShader();
+
+    std::string defines = "#version 330\n";
+
+    if (mSettings->mGraphics.pEnableHDR.get()) {
+      defines += "#define ENABLE_HDR\n";
+    }
+
+    mShader.InitVertexShaderFromString(defines + SPHERE_VERT);
+    mShader.InitFragmentShaderFromString(defines + SPHERE_FRAG);
+    mShader.Link();
+
+    mUniforms.modelViewMatrix  = mShader.GetUniformLocation("uMatModelView");
+    mUniforms.projectionMatrix = mShader.GetUniformLocation("uMatProjection");
+    mUniforms.surfaceTexture   = mShader.GetUniformLocation("uSurfaceTexture");
+    mUniforms.radii            = mShader.GetUniformLocation("uRadii");
+    mUniforms.farClip          = mShader.GetUniformLocation("uFarClip");
+    mUniforms.sunIlluminance   = mShader.GetUniformLocation("uSunIlluminance");
+
+    mShaderDirty = false;
+  }
 
   mShader.Bind();
 

--- a/plugins/csp-rings/src/Ring.hpp
+++ b/plugins/csp-rings/src/Ring.hpp
@@ -62,6 +62,9 @@ class Ring : public cs::scene::CelestialObject, public IVistaOpenGLDraw {
   VistaVertexArrayObject        mSphereVAO;
   VistaBufferObject             mSphereVBO;
 
+  bool mShaderDirty         = true;
+  int  mEnableHDRConnection = -1;
+
   struct {
     uint32_t modelViewMatrix  = 0;
     uint32_t projectionMatrix = 0;

--- a/plugins/csp-simple-bodies/src/SimpleBody.cpp
+++ b/plugins/csp-simple-bodies/src/SimpleBody.cpp
@@ -100,6 +100,8 @@ in vec2 vLngLat;
 // outputs
 layout(location = 0) out vec3 oColor;
 
+const float M_PI = 3.141592653589793;
+
 vec3 SRGBtoLINEAR(vec3 srgbIn)
 {
   vec3 bLess = step(vec3(0.04045),srgbIn);
@@ -111,10 +113,10 @@ void main()
     oColor = texture(uSurfaceTexture, vTexCoords).rgb;
 
     #ifdef ENABLE_HDR
-      oColor = SRGBtoLINEAR(oColor);
+      oColor = SRGBtoLINEAR(oColor) * uSunIlluminance / M_PI;
+    #else
+      oColor = oColor * uSunIlluminance;
     #endif
-
-    oColor = oColor * uSunIlluminance;
 
     #ifdef ENABLE_LIGHTING
       vec3 normal = normalize(vNormal);


### PR DESCRIPTION
In HDR rendering, we are missing a division by π to be ernergy-conserving for Lambertian surfaces. See https://seblagarde.wordpress.com/2012/01/08/pi-or-not-to-pi-in-game-lighting-equation/ for an explanation.

The brightness of the clouds in HDR mode is still quite arbitrary. This needs to be fixed in the future.