### PR TITLE
Safer Signals and Slots

### DIFF
--- a/src/cs-utils/Signal.hpp
+++ b/src/cs-utils/Signal.hpp
@@ -51,28 +51,46 @@ class Signal {
 
   /// Disconnects a previously connected function.
   void disconnect(int id) const {
-    mSlots.erase(id);
+    if (mIsIterating) {
+      mSlotsToDisconnect.push_back(id);
+    } else {
+      mSlots.erase(id);
+    }
   }
 
   /// Disconnects all previously connected functions.
   void disconnectAll() const {
-    mSlots.clear();
+    if (mIsIterating) {
+      mDisconnectAllRequested = true;
+    } else {
+      mSlots.clear();
+    }
   }
 
   /// Calls all connected functions.
   void emit(Args... p) {
+    mIsIterating = true;
+
     for (auto const& it : mSlots) {
       it.second(p...);
     }
+
+    mIsIterating = false;
+    postEmitCleanUp();
   }
 
   /// Calls all connected functions except for one.
   void emitForAllButOne(int excludedConnectionID, Args... p) {
+    mIsIterating = true;
+
     for (auto const& it : mSlots) {
       if (it.first != excludedConnectionID) {
         it.second(p...);
       }
     }
+
+    mIsIterating = false;
+    postEmitCleanUp();
   }
 
   /// Calls only one connected functions.
@@ -92,8 +110,23 @@ class Signal {
   }
 
  private:
+  void postEmitCleanUp() {
+    if (mDisconnectAllRequested) {
+      mSlots.clear();
+      mDisconnectAllRequested = false;
+    } else {
+      for (int id : mSlotsToDisconnect) {
+        mSlots.erase(id);
+      }
+    }
+  }
+
   mutable std::map<int, std::function<void(Args...)>> mSlots;
   mutable int                                         mCurrentID{0};
+
+  mutable bool             mIsIterating            = false;
+  mutable bool             mDisconnectAllRequested = false;
+  mutable std::vector<int> mSlotsToDisconnect;
 };
 
 } // namespace cs::utils

--- a/src/cs-utils/Signal.hpp
+++ b/src/cs-utils/Signal.hpp
@@ -11,7 +11,12 @@
 #include <iostream>
 #include <map>
 
+#include <cs_utils_export.hpp>
+#include <spdlog/spdlog.h>
+
 namespace cs::utils {
+
+CS_UTILS_EXPORT spdlog::logger& logger();
 
 /// A signal object may call multiple slots with the same signature. You can connect functions to
 /// the signal which will be called when the emit() method on the signal object is invoked. Any
@@ -69,6 +74,13 @@ class Signal {
 
   /// Calls all connected functions.
   void emit(Args... p) {
+    if (mIsIterating) {
+      logger().warn(
+          "Recursive invocation of emit! To avoid a stack overflow, the recursive invocation was "
+          "skipped. Some slots might not be informed about the most recent changes.");
+      return;
+    }
+
     mIsIterating = true;
 
     for (auto const& it : mSlots) {
@@ -81,6 +93,13 @@ class Signal {
 
   /// Calls all connected functions except for one.
   void emitForAllButOne(int excludedConnectionID, Args... p) {
+    if (mIsIterating) {
+      logger().warn(
+          "Recursive invocation of emit! To avoid a stack overflow, the recursive invocation was "
+          "skipped. Some slots might not be informed about the most recent changes.");
+      return;
+    }
+
     mIsIterating = true;
 
     for (auto const& it : mSlots) {

--- a/src/cs-utils/Signal.hpp
+++ b/src/cs-utils/Signal.hpp
@@ -118,6 +118,7 @@ class Signal {
       for (int id : mSlotsToDisconnect) {
         mSlots.erase(id);
       }
+      mSlotsToDisconnect.clear();
     }
   }
 

--- a/test/cs-utils/Signal.cpp
+++ b/test/cs-utils/Signal.cpp
@@ -1,0 +1,214 @@
+////////////////////////////////////////////////////////////////////////////////////////////////////
+//                               This file is part of CosmoScout VR                               //
+//      and may be used under the terms of the MIT license. See the LICENSE file for details.     //
+//                        Copyright: (c) 2019 German Aerospace Center (DLR)                       //
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include "../../src/cs-utils/Signal.hpp"
+#include "../../src/cs-utils/doctest.hpp"
+
+namespace cs::utils {
+TEST_CASE("cs::utils:Signal::emit") {
+  bool test = false;
+
+  Signal<bool> a;
+  a.connect([&](bool value) { test = value; });
+
+  a.emit(true);
+  CHECK(test);
+  a.disconnectAll();
+}
+
+TEST_CASE("cs::utils:Signal::emitForAllButOne") {
+  bool test1 = false;
+  bool test2 = false;
+  bool test3 = false;
+
+  Signal<bool> a;
+
+  int id = a.connect([&](bool value) { test1 = value; });
+  a.connect([&](bool value) { test2 = value; });
+  a.connect([&](bool value) { test3 = value; });
+
+  a.emitForAllButOne(id, true);
+
+  CHECK_FALSE(test1);
+  CHECK(test2);
+  CHECK(test3);
+
+  a.disconnectAll();
+}
+
+TEST_CASE("cs::utils:Signal::emitFor") {
+  bool test1 = false;
+  bool test2 = false;
+  bool test3 = false;
+
+  Signal<bool> a;
+
+  int id = a.connect([&](bool value) { test1 = value; });
+  a.connect([&](bool value) { test2 = value; });
+  a.connect([&](bool value) { test3 = value; });
+
+  a.emitFor(id, true);
+
+  CHECK(test1);
+  CHECK_FALSE(test2);
+  CHECK_FALSE(test3);
+
+  a.disconnectAll();
+}
+
+TEST_CASE("cs::utils:Signal::disconnect") {
+  bool test1 = false;
+  bool test2 = false;
+
+  Signal<bool> a;
+
+  int id = a.connect([&](bool value) { test1 = value; });
+  a.connect([&](bool value) { test2 = value; });
+
+  a.emit(true);
+  a.disconnect(id);
+  a.emit(false);
+
+  CHECK(test1);
+  CHECK_FALSE(test2);
+
+  a.disconnectAll();
+}
+
+TEST_CASE("cs::utils:Signal::disconnectAll") {
+  bool test1 = false;
+  bool test2 = false;
+
+  Signal<bool> a;
+
+  a.connect([&](bool value) { test1 = value; });
+  a.connect([&](bool value) { test2 = value; });
+
+  a.emit(true);
+  a.disconnectAll();
+  a.emit(false);
+
+  CHECK(test1);
+  CHECK(test2);
+}
+
+TEST_CASE("cs::utils::Signal disconnect one slot while emitting") {
+  bool test1 = false;
+  bool test2 = false;
+  bool test3 = false;
+
+  Signal<bool> a;
+
+  a.connect([&](bool value) { test1 = value; });
+  int id = a.connect([&](bool value) {
+    test2 = value;
+    a.disconnect(id);
+  });
+  a.connect([&](bool value) { test3 = value; });
+
+  a.emit(true);
+
+  CHECK(test1);
+  CHECK(test2);
+  CHECK(test3);
+
+  a.emit(false);
+
+  CHECK_FALSE(test1);
+  CHECK(test2);
+  CHECK_FALSE(test3);
+
+  a.disconnectAll();
+}
+
+TEST_CASE("cs::utils::Signal disconnect one slot while emitting for all but one") {
+  bool test1 = false;
+  bool test2 = false;
+  bool test3 = false;
+
+  Signal<bool> a;
+
+  int id1 = a.connect([&](bool value) { test1 = value; });
+  int id2 = a.connect([&](bool value) {
+    test2 = value;
+    a.disconnect(id2);
+  });
+  int id3 = a.connect([&](bool value) { test3 = value; });
+
+  a.emitForAllButOne(id1, true);
+
+  CHECK_FALSE(test1);
+  CHECK(test2);
+  CHECK(test3);
+
+  a.emitForAllButOne(id3, false);
+
+  CHECK_FALSE(test1);
+  CHECK(test2);
+  CHECK(test3);
+
+  a.disconnectAll();
+}
+
+TEST_CASE("cs::utils::Signal disconnect all slots while emitting") {
+  bool test1 = false;
+  bool test2 = false;
+  bool test3 = false;
+
+  Signal<bool> a;
+
+  a.connect([&](bool value) { test1 = value; });
+  a.connect([&](bool value) {
+    test2 = value;
+    a.disconnectAll();
+  });
+  a.connect([&](bool value) { test3 = value; });
+
+  a.emit(true);
+
+  CHECK(test1);
+  CHECK(test2);
+  CHECK(test3);
+
+  a.emit(false);
+
+  CHECK(test1);
+  CHECK(test2);
+  CHECK(test3);
+}
+
+TEST_CASE("cs::utils::Signal disconnect all slots while emitting for all but one") {
+  bool test1 = false;
+  bool test2 = false;
+  bool test3 = false;
+
+  Signal<bool> a;
+
+  int id1 = a.connect([&](bool value) { test1 = value; });
+  a.connect([&](bool value) {
+    test2 = value;
+    a.disconnectAll();
+  });
+  a.connect([&](bool value) { test3 = value; });
+
+  a.emitForAllButOne(id1, true);
+
+  CHECK_FALSE(test1);
+  CHECK(test2);
+  CHECK(test3);
+
+  test1 = false;
+  test2 = false;
+  test3 = false;
+
+  a.emit(true);
+
+  CHECK_FALSE(test1);
+  CHECK_FALSE(test2);
+  CHECK_FALSE(test3);
+}
+
+} // namespace cs::utils


### PR DESCRIPTION
Added safeguards, that prevent a crash, when a slot is disconnected while the signal is emitting all its slots.

The slots that are disconnected while emitting will be stored and disconnected after all other slots have been called.