### PR TITLE
Improved timings

### DIFF
--- a/plugins/csp-atmospheres/src/AtmosphereRenderer.cpp
+++ b/plugins/csp-atmospheres/src/AtmosphereRenderer.cpp
@@ -376,7 +376,7 @@ void AtmosphereRenderer::updateShader() {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 bool AtmosphereRenderer::Do() {
-  cs::utils::FrameTimings::ScopedTimer timer("csp-atmospheres");
+  cs::utils::FrameTimings::ScopedTimer timer("Render Atmosphere");
 
   if (mShaderDirty) {
     updateShader();

--- a/plugins/csp-lod-bodies/src/Plugin.cpp
+++ b/plugins/csp-lod-bodies/src/Plugin.cpp
@@ -446,14 +446,14 @@ void Plugin::update() {
     double minTime      = 13.5;
     double maxTime      = 14.5;
 
-    if (mFrameTimings->pFrameTime.get() > maxTime) {
-      mPluginSettings->mLODFactor = static_cast<float>(std::max(
-          minLODFactor, mPluginSettings->mLODFactor.get() -
-                            std::min(1.0, 0.1 * (mFrameTimings->pFrameTime.get() - maxTime))));
-    } else if (mFrameTimings->pFrameTime.get() < minTime) {
-      mPluginSettings->mLODFactor = static_cast<float>(std::min(
-          maxLODFactor, mPluginSettings->mLODFactor.get() +
-                            std::min(1.0, 0.02 * (minTime - mFrameTimings->pFrameTime.get()))));
+    if (cs::utils::FrameTimings::get().pFrameTime.get() > maxTime) {
+      mPluginSettings->mLODFactor = static_cast<float>(std::max(minLODFactor,
+          mPluginSettings->mLODFactor.get() -
+              std::min(1.0, 0.1 * (cs::utils::FrameTimings::get().pFrameTime.get() - maxTime))));
+    } else if (cs::utils::FrameTimings::get().pFrameTime.get() < minTime) {
+      mPluginSettings->mLODFactor = static_cast<float>(std::min(maxLODFactor,
+          mPluginSettings->mLODFactor.get() +
+              std::min(1.0, 0.02 * (minTime - cs::utils::FrameTimings::get().pFrameTime.get()))));
     }
   }
 }

--- a/plugins/csp-stars/src/Stars.cpp
+++ b/plugins/csp-stars/src/Stars.cpp
@@ -9,6 +9,7 @@
 #include "logger.hpp"
 
 #include "../../../src/cs-graphics/TextureLoader.hpp"
+#include "../../../src/cs-utils/FrameTimings.hpp"
 
 #ifdef _WIN32
 #include <Windows.h>
@@ -288,6 +289,8 @@ void Stars::setStarFiguresTexture(std::string const& filename) {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 bool Stars::Do() {
+  cs::utils::FrameTimings::ScopedTimer timer("Render Stars");
+
   // save current state of the OpenGL state machine
   glPushAttrib(GL_DEPTH_BUFFER_BIT | GL_COLOR_BUFFER_BIT | GL_ENABLE_BIT);
   glDepthMask(GL_FALSE);

--- a/plugins/csp-timings/README.md
+++ b/plugins/csp-timings/README.md
@@ -1,7 +1,7 @@
 # Frame-Timings for CosmoScout VR
 
 A plugin which uses the built-in timer queries of CosmoScout VR to draw on-screen live frame timing statistics.
-This plugin can also be used to export recorded time series to a CSV file (in milliseconds).
+This plugin can also be used to export recorded time series to a set of CSV files (in microseconds).
 
 ## Configuration
 
@@ -22,5 +22,5 @@ There are no configuration options, so this is all you need to do:
 ## Usage
 
 Once the plugin is loaded, you can enable the timer queries in the sidebar tab "Frame Timing".
-* When the timer queries are enabled, you can show the on-screen statistics.
-* You can also start a recording by clicking the big Record-Frame-Timings-button. Once you finish the recording, a file called `timing-<current date>.csv` will be written to CosmoScout VR's `bin` directory.
+* When the timer queries are enabled, you can show the on-screen statistics. Move the pointer over the statistics window to see more details.
+* You can also start a recording by clicking the big Record-Frame-Timings-button. Once you finish the recording, several CSV files will be written to a directory called `csp-timings/<current date>` in CosmoScout VR's `bin` directory. The files prefixed with `gpu-` contain GPU timing information, the others contain CPU timing data. The timing data is sorted by nesting level of the timed ranges - this means that the data in one file can be safely accumulated for one frame as it does not contain overlapping ranges. If timing ranges with the same name have been measured in one frame, their data will be accumulated in the files. 

--- a/plugins/csp-timings/gui/css/timings.css
+++ b/plugins/csp-timings/gui/css/timings.css
@@ -108,6 +108,7 @@
   left: -30px;
   display: flex;
   align-items: center;
+  overflow: hidden;
   transform: rotate(-90deg);
   opacity: 0;
   transition: opacity 0.3s;

--- a/plugins/csp-timings/gui/css/timings.css
+++ b/plugins/csp-timings/gui/css/timings.css
@@ -191,10 +191,18 @@
 
 #frame-slider-container {
   display: flex;
-  margin: 20px 10px 20px 30px;
+  margin: 10px 20px 0px 30px;
+  height: 0;
+  opacity: 0;
+  transition: height 0.3s, opacity 0.3s;
+}
+
+#timings:hover #frame-slider-container {
+  height: 20px;
+  opacity: 1;
 }
 
 #frame-slider {
-  margin-left: 40px;
+  margin-left: 30px;
   flex-grow: 1;
 }

--- a/plugins/csp-timings/gui/css/timings.css
+++ b/plugins/csp-timings/gui/css/timings.css
@@ -1,58 +1,182 @@
+/*                                                                                                */
+/*                                 Styling of the entire graph window                             */
+/*                                                                                                */
+
 #timings {
+  position: absolute;
+  width: 50vw;
+  right: 0;
   color: var(--cs-color-text);
-  margin: 0;
-  overflow: hidden;
   text-shadow: 1px 1px 2px #000;
-  position: absolute;
-  right: 0;
-  width: 100vw;
-  text-align: right;
+  text-align: center;
+  border-top-left-radius: var(--cs-border-radius-large);
+  border-bottom-left-radius: var(--cs-border-radius-large);
+  border-bottom: 2px solid var(--cs-color-primary);
+  border-top: 2px solid var(--cs-color-primary);
+  background-color: rgba(0, 0, 0, 0.5);
+  box-shadow: var(--cs-box-shadow-medium);
+
+  transition: width 0.2s;
 }
 
-#timings .timings-item {
+#fps-counter {
+  margin-top: 10px;
+}
+
+#graph {
   position: relative;
-  height: 24px;
-  margin-bottom: 5px;
-  overflow: visible;
-  white-space: nowrap;
-  background: linear-gradient(to left, rgba(20, 20, 20, 0.6) 0px, rgba(20, 20, 20, 0.0) 400px)
+  background-color: rgba(255, 255, 255, 0.1);
+  margin: 10px;
+  transition: margin 0.3s;
 }
 
-#timings>.label {
-  margin-bottom: 5px;
+/* Expand graph on hover */
+#timings:hover {
+  width: 100vw;
 }
 
-#timings .timings-item>.label {
+#timings:hover #graph {
+  margin: 10px 10px 30px 30px;
+}
+
+
+/*                                                                                                */
+/*                                 Styling of the individual ranges                               */
+/*                                                                                                */
+
+#ranges {
+  position: relative;
+  z-index: 1;
+}
+
+#ranges .level {
+  position: relative;
+  width: 100%;
+  height: 20px;
+}
+
+#ranges .range {
   position: absolute;
-  font-size: 16px;
-  padding-right: 65px;
-  padding-bottom: 3px;
-  min-width: 250px;
-  padding-top: 4px;
-  right: 0;
-  text-align: right;
-}
-
-#timings .bar {
-  position: absolute;
-  right: 0;
-  height: 12px;
-  font-size: 11px;
-}
-
-#timings .bar>.label {
-  position: absolute;
-  width: 60px;
-  right: 2px;
-  text-align: right;
-}
-
-#timings .bar.gpu {
   top: 0;
-  opacity: 1.0;
+  border-radius: 3px;
+  height: 18px;
 }
 
-#timings .bar.cpu {
-  top: 12px;
-  opacity: 0.8;
+/* Expand range on hover */
+#ranges .range:hover {
+  z-index: 1;
+  border: 3px solid rgba(255, 255, 255, 0);
+  transform: translate(-3px, -3px);
+}
+
+/* Show tooltip on hover */
+#ranges .range:hover::before {
+  content: attr(data-tooltip);
+  pointer-events: none;
+  font-size: 0.7em;
+  position: absolute;
+  top: -10px;
+  left: calc(var(--tooltip-offset));
+  transform: translateX(calc(-1*var(--tooltip-offset)));
+  border-radius: 3px;
+  background-color: inherit;
+  padding: 0 3px;
+  white-space: nowrap;
+}
+
+#gpu-ranges,
+#cpu-ranges {
+  position: relative;
+  transition: border 0.3s;
+}
+
+#timings:hover #gpu-ranges,
+#timings:hover #cpu-ranges {
+  border-left: 2px solid var(--cs-color-primary);
+}
+
+#gpu-ranges {
+  margin-bottom: 20px;
+}
+
+#gpu-ranges::before,
+#cpu-ranges::before {
+  content: "GPU";
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: -30px;
+  display: flex;
+  align-items: center;
+  transform: rotate(-90deg);
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+
+#timings:hover #gpu-ranges::before,
+#timings:hover #cpu-ranges::before {
+  opacity: 1;
+}
+
+#cpu-ranges::before {
+  content: "CPU";
+}
+
+
+
+/*                                                                                                */
+/*                                  Styling of the background grid                                */
+/*                                                                                                */
+
+#grid {
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  bottom: 0;
+  display: flex;
+  justify-content: space-between;
+}
+
+#grid .tick {
+  position: relative;
+  width: 1px;
+  height: 100%;
+}
+
+#grid .tick.major {
+  background-color: rgba(255, 255, 255, 0.4);
+}
+
+#grid .tick.minor {
+  background-color: rgba(255, 255, 255, 0);
+  transition: background-color 0.3s;
+}
+
+#timings:hover #grid .tick.minor {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+#grid .tick span {
+  position: absolute;
+  bottom: -20px;
+  left: -15px;
+  font-size: 0.8em;
+  white-space: nowrap;
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+
+#timings:hover #grid .tick span {
+  opacity: 1;
+}
+
+#grid .tick:first-child span {
+  left: 0;
+}
+
+#grid .tick:last-child span {
+  left: auto;
+  right: 0;
 }

--- a/plugins/csp-timings/gui/css/timings.css
+++ b/plugins/csp-timings/gui/css/timings.css
@@ -7,7 +7,6 @@
   width: 50vw;
   right: 0;
   color: var(--cs-color-text);
-  text-shadow: 1px 1px 2px #000;
   text-align: center;
   border-top-left-radius: var(--cs-border-radius-large);
   border-bottom-left-radius: var(--cs-border-radius-large);
@@ -179,4 +178,23 @@
 #grid .tick:last-child span {
   left: auto;
   right: 0;
+}
+
+
+/*                                                                                                */
+/*                                   Styling of the frame slider                                  */
+/*                                                                                                */
+
+.noUi-base {
+  margin-top: 0;
+}
+
+#frame-slider-container {
+  display: flex;
+  margin: 20px 10px 20px 30px;
+}
+
+#frame-slider {
+  margin-left: 40px;
+  flex-grow: 1;
 }

--- a/plugins/csp-timings/gui/js/csp-timings.js
+++ b/plugins/csp-timings/gui/js/csp-timings.js
@@ -60,7 +60,7 @@ class TimingsApi extends IApi {
 
     // Create the color hash object for coloring the timing ranges.
     if (typeof ColorHash !== 'undefined') {
-      this._colorHash = new ColorHash({lightness: 0.4, saturation: 0.3});
+      this._colorHash = new ColorHash({lightness: 0.3, saturation: 0.6});
     } else {
       console.error('Class \'ColorHash\' not defined.');
     }

--- a/plugins/csp-timings/gui/js/csp-timings.js
+++ b/plugins/csp-timings/gui/js/csp-timings.js
@@ -130,7 +130,7 @@ class TimingsApi extends IApi {
       // 1 2 5 10 20 50 100 200 500 1000 ....
       let int  = ~~(i / 3);
       let mod  = i % 3;
-      interval = (mod == 1 ? i * 2 : i * 2 + 1) * (int + 1);
+      interval = (mod === 1 ? i * 2 : i * 2 + 1) * (int + 1);
     }
 
     // Compute the number of required grid lines.
@@ -142,14 +142,14 @@ class TimingsApi extends IApi {
       // The last tick line will require a little bit of margin on the right hand side as the
       // maxTime will not be a full multiple of interval.
       let margin = "";
-      if (i == ticks) {
+      if (i === ticks) {
         let fullTickWidth = 100.0 / (ticks + 1);
         let remainder     = maxTime / interval - ticks;
         margin            = `style="margin-right: ${fullTickWidth * remainder}%"`;
       }
 
       // Every 5 ticks we add a major grid line.
-      if (i % 5 == 0) {
+      if (i % 5 === 0) {
         gridLines.innerHTML +=
             `<div class="tick major" ${margin}><span>${i * interval} ms</span></div>`
       } else {

--- a/plugins/csp-timings/gui/js/csp-timings.js
+++ b/plugins/csp-timings/gui/js/csp-timings.js
@@ -95,39 +95,50 @@ class TimingsApi extends IApi {
    *
    */
   _redraw() {
-    let gpuData = this._gpuData[this._frameIndex];
-    let cpuData = this._cpuData[this._frameIndex];
+    // Get the containers to draw to.
+    const gpuContainer  = document.querySelector("#gpu-ranges")
+    const cpuContainer  = document.querySelector("#cpu-ranges")
+    const gridContainer = document.querySelector("#grid")
+    const fpsContainer  = document.getElementById('fps-counter');
 
-    // Retrieve the end time values of the last root-level timing ranges. The maximum of these
-    // determines the maximum x-value of the graph.
-    let maxGPUTime = gpuData[0][gpuData[0].length - 1][2];
-    let maxCPUTime = cpuData[0][cpuData[0].length - 1][2];
-    let maxTime    = Math.max(maxGPUTime, maxCPUTime) * 0.001;
+    // First clear the containers completely.
+    CosmoScout.gui.clearHtml(gpuContainer);
+    CosmoScout.gui.clearHtml(cpuContainer);
+    CosmoScout.gui.clearHtml(gridContainer);
 
-    // With this value we can update the FPS display.
-    const item     = document.getElementById('fps-counter');
-    item.innerHTML = `FPS: ${(1000.0 / maxTime).toFixed(2)} / ${(maxTime).toFixed(2)} ms`;
+    if (this._frameIndex < this._gpuData.length && this._frameIndex < this._cpuData.length) {
+      let gpuData = this._gpuData[this._frameIndex];
+      let cpuData = this._cpuData[this._frameIndex];
 
-    // First we update the background grid.
-    this._drawGrid(maxTime);
+      // Retrieve the end time values of the last root-level timing ranges. The maximum of these
+      // determines the maximum x-value of the graph.
+      let maxGPUTime = gpuData[0][gpuData[0].length - 1][2];
+      let maxCPUTime = cpuData[0][cpuData[0].length - 1][2];
+      let maxTime    = Math.max(maxGPUTime, maxCPUTime) * 0.001;
 
-    // Then we draw the two graphs.
-    this._drawRanges("#gpu-ranges", gpuData, maxTime);
-    this._drawRanges("#cpu-ranges", cpuData, maxTime);
+      // With this value we can update the FPS display.
+      fpsContainer.innerHTML = `FPS: ${(1000.0 / maxTime).toFixed(2)} / ${(maxTime).toFixed(2)} ms`;
+
+      // First we update the background grid.
+      this._drawGrid(gridContainer, maxTime);
+
+      // Then we draw the two graphs.
+      this._drawRanges(gpuContainer, gpuData, maxTime);
+      this._drawRanges(cpuContainer, cpuData, maxTime);
+
+    } else {
+      fpsContainer.innerHTML = "There is no data available for this frame.";
+    }
   }
 
   /**
    * Draw the ranges of each level as small containers with a relative with and position.
    *
-   * @param {string} selector The container into which the range bars are drawn.
-   * @param {array}  data     The parsed JSON string passed to setData().
-   * @param {number} maxTime  The maximum x-value of the graph.
+   * @param {div}    container The container into which the range bars are drawn.
+   * @param {array}  data      The parsed JSON string passed to setData().
+   * @param {number} maxTime   The maximum x-value of the graph.
    */
-  _drawRanges(selector, data, maxTime) {
-
-    // First clear the container completely.
-    let container = document.querySelector(selector);
-    CosmoScout.gui.clearHtml(container);
+  _drawRanges(container, data, maxTime) {
 
     // This string will contain all the HTML of the graph.
     let html = "";
@@ -166,10 +177,11 @@ class TimingsApi extends IApi {
   /**
    * Draw a grid with major and minor ticks.
    *
-   * @param {number} maxTime
+   * @param {div}    container The container into which the grid is drawn.
+   * @param {number} maxTime   The total frame time in milliseconds.
    */
 
-  _drawGrid(maxTime) {
+  _drawGrid(container, maxTime) {
 
     // First clear the container completely.
     let grid = document.querySelector("#grid");

--- a/plugins/csp-timings/gui/js/csp-timings.js
+++ b/plugins/csp-timings/gui/js/csp-timings.js
@@ -186,7 +186,7 @@ class TimingsApi extends IApi {
 
       // For linearly increasing i, this results in these intervals:
       // 1 2 5 10 20 50 100 200 500 1000 ....
-      let int  = ~~(i / 3);
+      let int  = Math.floor(i / 3);
       let mod  = i % 3;
       interval = (mod === 1 ? i * 2 : i * 2 + 1) * (int + 1);
     }

--- a/plugins/csp-timings/gui/js/csp-timings.js
+++ b/plugins/csp-timings/gui/js/csp-timings.js
@@ -26,45 +26,64 @@ class TimingsApi extends IApi {
   }
 
   /**
-   *
+   * Both arguments should be JSON strings containing an array for each nesting level. Each element
+   * of these should contain an array of timing ranges. Each timing range is an array of three
+   * elements: [<name>, <frame-relative-start>, <frame-relative-end>].
    */
   setData(gpuData, cpuData) {
     const container = document.getElementById('timings');
 
+    // Only update the graph if it's not hovered.
     if (!container.matches(':hover')) {
 
       gpuData = JSON.parse(gpuData);
       cpuData = JSON.parse(cpuData);
 
-      // Retrieve the end time values of the last root-level timing ranges.
+      // Retrieve the end time values of the last root-level timing ranges. The maximum of these
+      // determines the maximum x-value of the graph.
       let maxGPUTime = gpuData[0][gpuData[0].length - 1][2];
       let maxCPUTime = cpuData[0][cpuData[0].length - 1][2];
       let maxTime    = Math.max(maxGPUTime, maxCPUTime) * 0.001;
 
+      // With this value we can update the FPS display.
       const item     = document.getElementById('fps-counter');
       item.innerHTML = `FPS: ${(1000.0 / maxTime).toFixed(2)} / ${(maxTime).toFixed(2)} ms`;
 
+      // First we update the background grid.
       this._drawGrid(maxTime);
+
+      // Then we draw the two graphs.
       this._drawRanges("#gpu-ranges", gpuData, maxTime);
       this._drawRanges("#cpu-ranges", cpuData, maxTime);
     }
   }
 
   /**
-   * Insert the actual html
+   * Draw the ranges of each level as small containers with a relative with and position.
    *
+   * @param {string} selector The container into which the range bars are drawn.
+   * @param {array}  data     The parsed JSON string passed to setData().
+   * @param {number} maxTime  The maximum x-value of the graph.
    */
   _drawRanges(selector, data, maxTime) {
+
+    // First clear the container completely.
     let container = document.querySelector(selector);
     CosmoScout.gui.clearHtml(container);
 
+    // This string will contain all the HTML of the graph.
     let html = "";
 
+    // Iterate through the nesting levels.
     for (let i = 0; i < data.length; i++) {
       const level = data[i];
 
+      // If there are ranges for this level...
       if (level) {
+
         html += "<div class='level'>";
+
+        // ... add one container for each.
         for (let j = 0; j < level.length; j++) {
           let name     = level[j][0];
           let duration = (level[j][2] - level[j][1]) * 0.001;
@@ -80,32 +99,48 @@ class TimingsApi extends IApi {
       }
     }
 
+    // Add the HTML to the document.
     const content     = document.createElement('template');
     content.innerHTML = html;
     container.appendChild(content.content);
   }
 
+  /**
+   * Draw a grid with major and minor ticks.
+   *
+   * @param {number} maxTime
+   */
+
   _drawGrid(maxTime) {
+
+    // First clear the container completely.
     let grid = document.querySelector("#grid");
     CosmoScout.gui.clearHtml(grid);
 
+    // First we determine a suitable interval between the minor ticks. We first assume 1(ms) but
+    // increase this if maxTime is quite large.
     let interval = 1;
     let i        = 0;
 
+    // If the current interval would result in more than 50 ticks, we increase the interval.
     while (maxTime / interval > 50) {
       ++i
 
-      let int = ~~(i / 3);
-      let mod = i % 3;
-
+      // For linearly increasing i, this results in these intervals:
+      // 1 2 5 10 20 50 100 200 500 1000 ....
+      let int  = ~~(i / 3);
+      let mod  = i % 3;
       interval = (mod == 1 ? i * 2 : i * 2 + 1) * (int + 1);
     }
 
+    // Compute the number of required grid lines.
     let ticks       = Math.floor(maxTime / interval);
     const gridLines = document.createElement('template');
 
     for (let i = 0; i <= ticks; i++) {
 
+      // The last tick line will require a little bit of margin on the right hand side as the
+      // maxTime will not be a full multiple of interval.
       let margin = "";
       if (i == ticks) {
         let fullTickWidth = 100.0 / (ticks + 1);
@@ -113,6 +148,7 @@ class TimingsApi extends IApi {
         margin            = `style="margin-right: ${fullTickWidth * remainder}%"`;
       }
 
+      // Every 5 ticks we add a major grid line.
       if (i % 5 == 0) {
         gridLines.innerHTML +=
             `<div class="tick major" ${margin}><span>${i * interval} ms</span></div>`

--- a/plugins/csp-timings/gui/js/csp-timings.js
+++ b/plugins/csp-timings/gui/js/csp-timings.js
@@ -10,22 +10,6 @@ class TimingsApi extends IApi {
   name = 'timings';
 
   /**
-   * Timing values
-   *
-   * @type {*[]}
-   * @private
-   */
-  _values = [];
-
-  /**
-   * Parsed json
-   *
-   * @type {Array}
-   * @private
-   */
-  _data;
-
-  /**
    * ColorHash object
    *
    * @type {ColorHash}
@@ -33,29 +17,9 @@ class TimingsApi extends IApi {
    */
   _colorHash;
 
-  /**
-   * Min time to be used for calculations
-   *
-   * @type {number}
-   * @private
-   */
-  _minTime = 1000;
-
-  /**
-   * @type {number}
-   * @private
-   */
-  _maxValue = 1e9 / 30;
-
-  /**
-   * @type {number}
-   * @private
-   */
-  _alpha = 0.95;
-
   init() {
     if (typeof ColorHash !== 'undefined') {
-      this._colorHash = new ColorHash({lightness: 0.5, saturation: 0.3});
+      this._colorHash = new ColorHash({lightness: 0.5, saturation: 0.4});
     } else {
       console.error('Class \'ColorHash\' not defined.');
     }
@@ -63,113 +27,100 @@ class TimingsApi extends IApi {
 
   /**
    *
-   * @param data {string}
-   * @param frameRate {number}
    */
-  setData(data, frameRate) {
-    this._data = JSON.parse(data);
+  setData(gpuData, cpuData) {
+    const container = document.getElementById('timings');
 
-    // first set all times to zero
-    this._resetTimes();
+    if (!container.matches(':hover')) {
 
-    // then add all new elements
-    this._addNewElements();
+      gpuData = JSON.parse(gpuData);
+      cpuData = JSON.parse(cpuData);
 
-    // remove all with very little contribution
-    const minTime = (element) =>
-        element.timeGPU > this._minTime || element.timeCPU > this._minTime ||
-        element.avgTimeGPU > this._minTime || element.avgTimeCPU > this._minTime;
-    this._values = this._values.filter(minTime);
+      // Retrieve the end time values of the last root-level timing ranges.
+      let maxGPUTime = gpuData[0][gpuData[0].length - 1][2];
+      let maxCPUTime = cpuData[0][cpuData[0].length - 1][2];
+      let maxTime    = Math.max(maxGPUTime, maxCPUTime) * 0.001;
 
-    // update average values
-    this._values.forEach((element) => {
-      element.avgTimeGPU = element.avgTimeGPU * this._alpha + element.timeGPU * (1 - this._alpha);
-      element.avgTimeCPU = element.avgTimeCPU * this._alpha + element.timeCPU * (1 - this._alpha);
-    });
+      const item     = document.getElementById('fps-counter');
+      item.innerHTML = `FPS: ${(1000.0 / maxTime).toFixed(2)} / ${(maxTime).toFixed(2)} ms`;
 
-    // sort by average
-    this._values.sort((a, b) => (b.avgTimeGPU + b.avgTimeCPU) - (a.avgTimeGPU + a.avgTimeCPU));
-
-    this._insertHtml(frameRate);
-  }
-
-  /**
-   * Reset times
-   *
-   * @see {_data}
-   * @private
-   */
-  _resetTimes() {
-    this._values.forEach((value) => {
-      if (typeof this._data[value.name] !== 'undefined') {
-        [value.timeGPU, value.timeCPU] = this._data[value.name];
-
-        this._data[value.name][0] = -1;
-        this._data[value.name][1] = -1;
-      } else {
-        value.timeGPU = 0;
-        value.timeCPU = 0;
-      }
-    });
-  }
-
-  /**
-   * Add elements to _values
-   *
-   * @see {_values}
-   * @private
-   */
-  _addNewElements() {
-    Object.keys(this._data).forEach((key) => {
-      if (this._data[key][0] >= 0) {
-        this._values.push({
-          name: key,
-          timeGPU: this._data[key][0],
-          timeCPU: this._data[key][1],
-          avgTimeGPU: this._data[key][0],
-          avgTimeCPU: this._data[key][1],
-          color: this._colorHash.hex(key),
-        });
-      }
-    });
+      this._drawGrid(maxTime);
+      this._drawRanges("#gpu-ranges", gpuData, maxTime);
+      this._drawRanges("#cpu-ranges", cpuData, maxTime);
+    }
   }
 
   /**
    * Insert the actual html
    *
-   * @param frameRate {number}
-   * @private
    */
-  _insertHtml(frameRate) {
-    const container = document.getElementById('timings');
+  _drawRanges(selector, data, maxTime) {
+    let container = document.querySelector(selector);
     CosmoScout.gui.clearHtml(container);
 
-    const maxEntries = Math.min(10, this._values.length);
-    const maxWidth   = container.offsetWidth;
+    let html = "";
 
-    const item = document.createElement('template');
+    for (let i = 0; i < data.length; i++) {
+      const level = data[i];
 
-    item.innerHTML = `<div class="label"><strong>FPS: ${frameRate.toFixed(2)}</strong></div>`;
+      if (level) {
+        html += "<div class='level'>";
+        for (let j = 0; j < level.length; j++) {
+          let name     = level[j][0];
+          let duration = (level[j][2] - level[j][1]) * 0.001;
+          let start    = (level[j][1] * 0.001) / maxTime * 100;
+          let end      = (level[j][2] * 0.001) / maxTime * 100;
 
-    container.appendChild(item.content);
-
-    for (let i = 0; i < maxEntries; ++i) {
-      /* eslint-disable no-mixed-operators */
-      const widthGPU = maxWidth * this._values[i].avgTimeGPU / this._maxValue;
-      const widthCPU = maxWidth * this._values[i].avgTimeCPU / this._maxValue;
-      /* eslint-enable no-mixed-operators */
-
-      item.innerHTML += `<div class="timings-item">
-        <div class="bar gpu" style="background-color:${this._values[i].color}; width:${
-          widthGPU}px"><div class="label">gpu: ${
-          (this._values[i].avgTimeGPU * 0.000001).toFixed(1)} ms</div></div>
-        <div class="bar cpu" style="background-color:${this._values[i].color}; width:${
-          widthCPU}px"><div class="label">cpu: ${
-          (this._values[i].avgTimeCPU * 0.000001).toFixed(1)} ms</div></div>
-        <div class="label">${this._values[i].name}</div>
-      </div>`;
-
-      container.appendChild(item.content);
+          html += `<div class="range" data-tooltip="${name} (${
+              duration.toFixed(
+                  2)} ms)" style="--tooltip-offset:${(start + end) / 2}%; left: ${start}%; width: ${
+              end - start}%; background-color: ${this._colorHash.hex(name)}"></div>`;
+        }
+        html += "</div>";
+      }
     }
+
+    const content     = document.createElement('template');
+    content.innerHTML = html;
+    container.appendChild(content.content);
+  }
+
+  _drawGrid(maxTime) {
+    let grid = document.querySelector("#grid");
+    CosmoScout.gui.clearHtml(grid);
+
+    let interval = 1;
+    let i        = 0;
+
+    while (maxTime / interval > 50) {
+      ++i
+
+      let int = ~~(i / 3);
+      let mod = i % 3;
+
+      interval = (mod == 1 ? i * 2 : i * 2 + 1) * (int + 1);
+    }
+
+    let ticks       = Math.floor(maxTime / interval);
+    const gridLines = document.createElement('template');
+
+    for (let i = 0; i <= ticks; i++) {
+
+      let margin = "";
+      if (i == ticks) {
+        let fullTickWidth = 100.0 / (ticks + 1);
+        let remainder     = maxTime / interval - ticks;
+        margin            = `style="margin-right: ${fullTickWidth * remainder}%"`;
+      }
+
+      if (i % 5 == 0) {
+        gridLines.innerHTML +=
+            `<div class="tick major" ${margin}><span>${i * interval} ms</span></div>`
+      } else {
+        gridLines.innerHTML += `<div class="tick minor" ${margin}></div>`;
+      }
+    }
+
+    grid.appendChild(gridLines.content);
   }
 }

--- a/plugins/csp-timings/gui/timings.html
+++ b/plugins/csp-timings/gui/timings.html
@@ -14,6 +14,12 @@
 <body>
   <div id="timings" class="font-ubuntu">
     <div id="fps-counter">60 FPS / 16.7 ms</div>
+
+    <div id="frame-slider-container">
+      <div>Displayed Frame</div>
+      <div id="frame-slider"></div>
+    </div>
+
     <div id="graph">
 
       <div id="ranges">
@@ -104,10 +110,6 @@
 
     </div>
 
-    <div id="frame-slider-container">
-      <div>Displayed Frame</div>
-      <div id="frame-slider"></div>
-    </div>
   </div>
 
   <script type="text/javascript" src="third-party/js/color-hash.js"></script>

--- a/plugins/csp-timings/gui/timings.html
+++ b/plugins/csp-timings/gui/timings.html
@@ -5,6 +5,8 @@
   <meta charset="UTF-8">
   <title>CosmoScout Frame Timings</title>
 
+  <link type="text/css" rel="stylesheet" href="third-party/css/nouislider.css">
+
   <link type="text/css" rel="stylesheet" href="css/gui.css">
   <link type="text/css" rel="stylesheet" href="css/timings.css">
 </head>
@@ -101,12 +103,19 @@
       </div>
 
     </div>
+
+    <div id="frame-slider-container">
+      <div>Displayed Frame</div>
+      <div id="frame-slider"></div>
+    </div>
   </div>
 
   <script type="text/javascript" src="third-party/js/color-hash.js"></script>
+  <script type="text/javascript" src="third-party/js/nouislider.min.js"></script>
 
   <script type="text/javascript" src="js/api.js"></script>
   <script type="text/javascript" src="js/cosmoscout.js"></script>
+  <script type="text/javascript" src="js/apis/utils.js"></script>
   <script type="text/javascript" src="js/apis/gui.js"></script>
   <script type="text/javascript" src="js/csp-timings.js"></script>
 
@@ -114,6 +123,7 @@
     var CosmoScout = new CosmoScoutAPI();
     document.addEventListener('DOMContentLoaded', () => {
       CosmoScout.init(
+        UtilsApi,
         GuiApi,
         TimingsApi
       );

--- a/plugins/csp-timings/gui/timings.html
+++ b/plugins/csp-timings/gui/timings.html
@@ -10,7 +10,98 @@
 </head>
 
 <body>
-  <div id="timings" class="font-ubuntu"></div>
+  <div id="timings" class="font-ubuntu">
+    <div id="fps-counter">60 FPS / 16.7 ms</div>
+    <div id="graph">
+
+      <div id="ranges">
+
+        <div id="gpu-ranges">
+
+          <!-- This container is filled with JavaScript with something similar to the elements below.
+               If you want to tweak the appearance of the range bars, you can uncomment these lines
+               and view this file in Chrome. -->
+
+          <!-- <div class="level">
+            <div class="range" data-tooltip="Foo (3 ms)" style="left: 4%; width: 20%; background-color: rgb(170, 138, 51);">
+            </div>
+            <div class="range" data-tooltip="Foo (3 ms)" style="left: 28%; width: 10%; background-color: rgb(170, 51, 154);">
+            </div>
+          </div>
+          <div class="level">
+            <div class="range" data-tooltip="Foo (3 ms)" style="left: 0%; width: 100%; background-color: rgb(89, 170, 51);">
+            </div>
+          </div>
+          <div class="level">
+            <div class="range" data-tooltip="Foo (3 ms)" style="left: 10%; width: 40%; background-color: #3a8;"></div>
+          </div> -->
+
+        </div>
+
+        <div id="cpu-ranges">
+
+          <!-- This container is filled with JavaScript with something similar to the elements below.
+               If you want to tweak the appearance of the range bars, you can uncomment these lines
+               and view this file in Chrome. -->
+
+          <!-- <div class="level">
+            <div class="range" data-tooltip="Foo (3 ms)"
+              style="--tooltip-offset:4%; left: 4%; width: 20%; background-color: rgb(170, 138, 51);">
+            </div>
+            <div class="range" data-tooltip="Foo (3 ms)"
+              style="--tooltip-offset:28%; left: 28%; width: 10%; background-color: rgb(170, 51, 154);">
+            </div>
+          </div>
+          <div class="level">
+            <div class="range" data-tooltip="Foo (3 ms)"
+              style="--tooltip-offset:0%; left: 0%; width: 50%; background-color: rgb(89, 170, 51);">
+            </div>
+            <div class="range" data-tooltip="Foo (3 ms)"
+              style="--tooltip-offset:52%; left: 52%; width: 1%; background-color: rgb(74, 181, 207);">
+            </div>
+          </div>
+          <div class="level">
+            <div class="range" data-tooltip="Foo (3 ms)"
+              style="--tooltip-offset:0%; left: 0%; width: 2%; background-color: #3a8;"></div>
+            <div class="range" data-tooltip="Foo (3 ms)"
+              style="--tooltip-offset:98%; left: 98%; width: 2%; background-color: #3a8;"></div>
+          </div> -->
+
+        </div>
+
+      </div>
+
+      <div id="grid">
+
+        <!-- This container is filled with JavaScript with something similar to the elements below.
+        If you want to tweak the appearance of the grid lines, you can uncomment these lines and
+        view this file in Chrome. -->
+
+        <!-- <div class="tick major"><span>0 ms</span></div>
+        <div class="tick minor"></div>
+        <div class="tick minor"></div>
+        <div class="tick minor"></div>
+        <div class="tick minor"></div>
+        <div class="tick major"><span>5 ms</span></div>
+        <div class="tick minor"></div>
+        <div class="tick minor"></div>
+        <div class="tick minor"></div>
+        <div class="tick minor"></div>
+        <div class="tick major"><span>10 ms</span></div>
+        <div class="tick minor"></div>
+        <div class="tick minor"></div>
+        <div class="tick minor"></div>
+        <div class="tick minor"></div>
+        <div class="tick major"><span>15 ms</span></div>
+        <div class="tick minor"></div>
+        <div class="tick minor"></div>
+        <div class="tick minor"></div>
+        <div class="tick minor"></div>
+        <div class="tick major" style="margin-right: 7%;"><span>20 ms</span></div> -->
+      </div>
+
+    </div>
+  </div>
 
   <script type="text/javascript" src="third-party/js/color-hash.js"></script>
 

--- a/plugins/csp-timings/src/Plugin.cpp
+++ b/plugins/csp-timings/src/Plugin.cpp
@@ -129,7 +129,7 @@ void Plugin::update() {
     auto const&    ranges          = cs::utils::FrameTimings::get().getRanges();
     uint32_t       maxNestingLevel = 0;
 
-    // Compute the maximum nesting level amongst all recoreded ranges.
+    // Compute the maximum nesting level amongst all recorded ranges.
     for (auto const& range : ranges) {
       maxNestingLevel = std::max(maxNestingLevel, range.mNestingLevel);
     }
@@ -205,7 +205,7 @@ void Plugin::update() {
 
     // This stores a CSV file for each nesting level in the directory created above. The prefix will
     // be prepended to the CSV file name.
-    auto saveRecording = [directory](std::string const&                          prefix,
+    auto saveRecording = [&directory](std::string const&                          prefix,
                              std::vector<std::vector<std::vector<Range>>> const& recording) {
       // Retrieve the maximum nesting level amongst all recorded frames. We need this to decide how
       // many files to create. The nesting level may actually change during a recording if for

--- a/plugins/csp-timings/src/Plugin.cpp
+++ b/plugins/csp-timings/src/Plugin.cpp
@@ -9,10 +9,9 @@
 #include "../../../src/cs-core/GuiManager.hpp"
 #include "../../../src/cs-core/PluginBase.hpp"
 #include "../../../src/cs-utils/convert.hpp"
+#include "../../../src/cs-utils/filesystem.hpp"
 #include "logger.hpp"
 
-#include <VistaKernel/VistaFrameLoop.h>
-#include <VistaKernel/VistaSystem.h>
 #include <iostream>
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -46,13 +45,13 @@ void Plugin::init() {
       "file://{mainUIZoom}../share/resources/gui/timings.html", false);
 
   // Configure the positioning and attributes of the statistics GUI item.
-  mGuiItem->setSizeX(600);
-  mGuiItem->setSizeY(320);
-  mGuiItem->setOffsetX(-300);
-  mGuiItem->setOffsetY(500);
-  mGuiItem->setRelPositionY(0.F);
+  mGuiItem->setSizeX(500);
+  mGuiItem->setSizeY(300);
+  mGuiItem->setOffsetX(-250);
+  mGuiItem->setOffsetY(0);
+  mGuiItem->setRelPositionY(0.5F);
   mGuiItem->setRelPositionX(1.F);
-  mGuiItem->setIsInteractive(false);
+  mGuiItem->setIsInteractive(true);
   mGuiItem->setCanScroll(false);
   mGuiItem->setIsEnabled(false);
 
@@ -68,10 +67,10 @@ void Plugin::init() {
   mGuiManager->getGui()->registerCallback("timings.setEnableTimerQueries",
       "Enables or disables execution of timer queries for each frame.",
       std::function([this](bool enable) {
-        mFrameTimings->pEnableMeasurements = enable;
+        cs::utils::FrameTimings::get().pEnableMeasurements = enable;
 
-        // If mFrameTimings->pEnableMeasurements are disabled, we make the two checkboxes of this
-        // plugin unresponsive.
+        // If cs::utils::FrameTimings::get().pEnableMeasurements are disabled, we make the two
+        // checkboxes of this plugin unresponsive.
         if (enable) {
           mGuiManager->getGui()->executeJavascript(
               "document.querySelectorAll('.enable-if-timer-enabled').forEach((elem) => "
@@ -83,10 +82,11 @@ void Plugin::init() {
         }
       }));
 
-  // Use the current state of mFrameTimings->pEnableMeasurements for our checkbox.
-  mFrameTimingConnection = mFrameTimings->pEnableMeasurements.connectAndTouch([this](bool enable) {
-    mGuiManager->setCheckboxValue("timings.setEnableTimerQueries", enable);
-  });
+  // Use the current state of cs::utils::FrameTimings::get().pEnableMeasurements for our checkbox.
+  mFrameTimingConnection =
+      cs::utils::FrameTimings::get().pEnableMeasurements.connectAndTouch([this](bool enable) {
+        mGuiManager->setCheckboxValue("timings.setEnableTimerQueries", enable);
+      });
 
   // Set the mEnableRecording value based on the corresponding checkbox.
   mGuiManager->getGui()->registerCallback("timings.setEnableRecording",
@@ -117,50 +117,79 @@ void Plugin::init() {
 void Plugin::update() {
 
   // Enable or disable the statistics GUI item if necessary.
-  mGuiItem->setIsEnabled(mEnableStatistics && mFrameTimings->pEnableMeasurements.get());
+  mGuiItem->setIsEnabled(
+      mEnableStatistics && cs::utils::FrameTimings::get().pEnableMeasurements.get());
 
   // If frame timings are enabled, we may have to record them or update the on-screen statistics.
-  if (mFrameTimings->pEnableMeasurements.get()) {
+  if (cs::utils::FrameTimings::get().pEnableMeasurements.get() &&
+      (mEnableRecording || mEnableStatistics)) {
 
-    // Get the frame timing information if either recording or the on-screen statistics are enabled.
-    std::unordered_map<std::string, cs::utils::FrameTimings::QueryResult> timings;
-    if (mEnableStatistics || mEnableRecording) {
-      timings = mFrameTimings->getCalculatedQueryResults();
+    // Only record ranges longer than 10 µs.
+    const uint32_t minTimeNanos    = 1e4;
+    auto const&    ranges          = cs::utils::FrameTimings::get().getRanges();
+    uint32_t       maxNestingLevel = 0;
+
+    // Compute the maximum nesting level amongst all recoreded ranges.
+    for (auto const& range : ranges) {
+      maxNestingLevel = std::max(maxNestingLevel, range.mNestingLevel);
+    }
+
+    // The outer vector contains all ranges for a specific nesting level.
+    std::vector<std::vector<Range>> cpuRanges(maxNestingLevel + 1);
+    std::vector<std::vector<Range>> gpuRanges(maxNestingLevel + 1);
+
+    // Compute frame-relative timestamps in microseconds.
+    if (!ranges.empty()) {
+      auto gpuFrameStart = ranges[0].mGPUStart;
+      auto cpuFrameStart = ranges[0].mCPUStart;
+
+      for (auto const& range : ranges) {
+        if (range.mGPUEnd - range.mGPUStart >= minTimeNanos) {
+          gpuRanges[range.mNestingLevel].emplace_back(range.mName,
+              (range.mGPUStart - gpuFrameStart) / 1000, (range.mGPUEnd - gpuFrameStart) / 1000);
+        }
+
+        if (range.mCPUEnd - range.mCPUStart >= minTimeNanos) {
+          cpuRanges[range.mNestingLevel].emplace_back(range.mName,
+              (range.mCPUStart - cpuFrameStart) / 1000, (range.mCPUEnd - cpuFrameStart) / 1000);
+        }
+      }
     }
 
     // Send the timing information to the statistics GUI item.
     if (mEnableStatistics) {
-      std::string json("{");
-      for (auto const& timing : timings) {
-        uint64_t timeGPU(timing.second.mGPUTime);
-        uint64_t timeCPU(timing.second.mCPUTime);
+      auto toJSON = [](std::vector<std::vector<Range>> const& ranges) {
+        nlohmann::json json;
 
-        uint64_t const thresholdNanos = 100000;
-        if (timeGPU > thresholdNanos || timeCPU > thresholdNanos) {
-          json += "\"" + timing.first + "\":[" + std::to_string(timeGPU) + "," +
-                  std::to_string(timeCPU) + "],";
+        for (uint32_t i = 0; i < ranges.size(); ++i) {
+          nlohmann::json level;
+          for (auto const& range : ranges[i]) {
+            nlohmann::json item;
+            item.push_back(range.mName);
+            item.push_back(range.mStart);
+            item.push_back(range.mEnd);
+            level.push_back(item);
+          }
+          json.push_back(level);
         }
-      }
-      json.back() = '}';
 
-      if (json.length() <= 1) {
-        json = "{}";
-      }
+        return json.dump();
+      };
 
-      mGuiItem->callJavascript(
-          "CosmoScout.timings.setData", json, GetVistaSystem()->GetFrameLoop()->GetFrameRate());
+      mGuiItem->callJavascript("CosmoScout.timings.setData", toJSON(gpuRanges), toJSON(cpuRanges));
     }
 
     // Store the frame timing if we are in recording-mode.
     if (mEnableRecording) {
-      mRecordedTimings.emplace_back(timings);
+      mRecordedGPURanges.push_back(std::move(gpuRanges));
+      mRecordedCPURanges.push_back(std::move(cpuRanges));
     }
   }
 
   // Recording seems to have stopped last frame, so write the output file!
-  if (!mEnableRecording && !mRecordedTimings.empty()) {
+  if (!mEnableRecording && !mRecordedGPURanges.empty()) {
 
-    // We use the current date as a filename.
+    // We use the current date as a directory name.
     auto timeString =
         cs::utils::convert::time::toString(boost::posix_time::microsec_clock::local_time());
     cs::utils::replaceString(timeString, ":", "-");
@@ -168,45 +197,76 @@ void Plugin::update() {
     cs::utils::replaceString(timeString, "T", "-");
     cs::utils::replaceString(timeString, "Z", "");
 
-    std::ofstream file("timing-" + timeString + ".csv");
+    std::string directory = "csp-timings/" + timeString;
+    cs::utils::filesystem::createDirectoryRecursively(
+        boost::filesystem::system_complete(directory));
 
-    // First we collect all unique timer names. There may have been different timers active during
-    // our recording session.
-    std::set<std::string> timerNames;
-    for (auto const& frameTiming : mRecordedTimings) {
-      for (auto const& timing : frameTiming) {
-        timerNames.insert(timing.first);
+    // This stores a CSV file for each nesting level in the directory created above. The prefix will
+    // be prepended to the CSV file name.
+    auto saveRecording = [directory](std::string const&                          prefix,
+                             std::vector<std::vector<std::vector<Range>>> const& recording) {
+      // Retrieve the maximum nesting level amongst all recorded frames. We need this to decide how
+      // many files to create. The nesting level may actually change during a recording if for
+      // example new objects come into view.
+      std::size_t maxNestingLevel = 0;
+      for (auto const& record : recording) {
+        maxNestingLevel = std::max(maxNestingLevel, record.size());
       }
-    }
 
-    // First we write the CSV heading. The first column contains the frame number.
-    file << "frame";
-    for (auto timerName : timerNames) {
-      // Make sure that there are no ',' in the timer names.
-      cs::utils::replaceString(timerName, ",", "_");
-      file << ", " << timerName << " (CPU), " << timerName << " (GPU)";
-    }
-    file << std::endl;
+      // Create a file for each nesting level.
+      for (std::size_t level = 0; level < maxNestingLevel; ++level) {
 
-    // Now we write the time series in the following lines.
-    uint32_t frameCounter = 0;
+        std::ofstream csv(directory + "/" + prefix + "-level-" + std::to_string(level) + ".csv");
 
-    for (auto const& frameTiming : mRecordedTimings) {
-      file << frameCounter++;
-      for (auto const& timerName : timerNames) {
-        auto it = frameTiming.find(timerName);
+        // Find unique range names in current level over all recorded frames.
+        std::set<std::string> rangeNames;
+        for (auto const& record : recording) {
+          for (auto const& range : record[level]) {
+            std::string name = range.mName;
+            cs::utils::replaceString(name, ",", "_");
+            rangeNames.insert(name);
+          }
+        }
 
-        if (it != frameTiming.end()) {
-          file << fmt::format(
-              ", {}, {}", it->second.mCPUTime * 0.000001, it->second.mGPUTime * 0.000001);
-        } else {
-          file << ", 0, 0";
+        // Write CSV header.
+        csv << "Frame";
+        for (auto const& name : rangeNames) {
+          csv << ", " << name;
+        }
+        csv << std::endl;
+
+        // Write one CSV line for each frame. If a range has not been recorded for a specific frame,
+        // a zero will be written to the corresponding field.
+        for (std::size_t i = 0; i < recording.size(); ++i) {
+
+          // Accumulate time per range as there may be multiple ranges with the same name.
+          std::map<std::string, uint32_t> rangeTimes;
+          for (auto const& name : rangeNames) {
+            rangeTimes[name] = 0;
+          }
+
+          for (auto const& range : recording[i][level]) {
+            std::string name = range.mName;
+            cs::utils::replaceString(name, ",", "_");
+            rangeTimes[name] += range.mEnd - range.mStart;
+          }
+
+          // Write the individual values to the CSV file.
+          csv << i;
+          for (auto const& time : rangeTimes) {
+            csv << ", " << time.second;
+          }
+          csv << std::endl;
         }
       }
-      file << std::endl;
-    }
+    };
 
-    mRecordedTimings.clear();
+    // Call the lambda above, once for the GPU timings, once for the CPU timings.
+    saveRecording("gpu", mRecordedGPURanges);
+    saveRecording("cpu", mRecordedCPURanges);
+
+    mRecordedGPURanges.clear();
+    mRecordedCPURanges.clear();
   }
 }
 
@@ -227,7 +287,7 @@ void Plugin::deInit() {
   mGuiManager->getLocalGuiArea().removeItem(mGuiItem.get());
 
   // Disconnect any signals.
-  mFrameTimings->pEnableMeasurements.disconnect(mFrameTimingConnection);
+  cs::utils::FrameTimings::get().pEnableMeasurements.disconnect(mFrameTimingConnection);
 
   logger().info("Unloading done.");
 }

--- a/plugins/csp-timings/src/Plugin.cpp
+++ b/plugins/csp-timings/src/Plugin.cpp
@@ -163,16 +163,16 @@ void Plugin::update() {
       auto toJSON = [](std::vector<std::vector<Range>> const& ranges) {
         nlohmann::json json;
 
-        for (uint32_t i = 0; i < ranges.size(); ++i) {
-          nlohmann::json level;
-          for (auto const& range : ranges[i]) {
-            nlohmann::json item;
-            item.push_back(range.mName);
-            item.push_back(range.mStart);
-            item.push_back(range.mEnd);
-            level.push_back(item);
+        for (auto const& level : ranges) {
+          nlohmann::json levelJSON;
+          for (auto const& range : level) {
+            nlohmann::json rangeJSON;
+            rangeJSON.push_back(range.mName);
+            rangeJSON.push_back(range.mStart);
+            rangeJSON.push_back(range.mEnd);
+            levelJSON.push_back(rangeJSON);
           }
-          json.push_back(level);
+          json.push_back(levelJSON);
         }
 
         return json.dump();
@@ -205,7 +205,7 @@ void Plugin::update() {
 
     // This stores a CSV file for each nesting level in the directory created above. The prefix will
     // be prepended to the CSV file name.
-    auto saveRecording = [&directory](std::string const&                          prefix,
+    auto saveRecording = [&directory](std::string const&                         prefix,
                              std::vector<std::vector<std::vector<Range>>> const& recording) {
       // Retrieve the maximum nesting level amongst all recorded frames. We need this to decide how
       // many files to create. The nesting level may actually change during a recording if for

--- a/plugins/csp-timings/src/Plugin.cpp
+++ b/plugins/csp-timings/src/Plugin.cpp
@@ -125,7 +125,7 @@ void Plugin::update() {
       (mEnableRecording || mEnableStatistics)) {
 
     // Only record ranges longer than 10 µs.
-    const uint32_t minTimeNanos    = 1e4;
+    const uint32_t minTimeNanos    = 10000;
     auto const&    ranges          = cs::utils::FrameTimings::get().getRanges();
     uint32_t       maxNestingLevel = 0;
 
@@ -146,12 +146,14 @@ void Plugin::update() {
       for (auto const& range : ranges) {
         if (range.mGPUEnd - range.mGPUStart >= minTimeNanos) {
           gpuRanges[range.mNestingLevel].emplace_back(range.mName,
-              (range.mGPUStart - gpuFrameStart) / 1000, (range.mGPUEnd - gpuFrameStart) / 1000);
+              static_cast<uint32_t>(range.mGPUStart - gpuFrameStart) / 1000,
+              static_cast<uint32_t>(range.mGPUEnd - gpuFrameStart) / 1000);
         }
 
         if (range.mCPUEnd - range.mCPUStart >= minTimeNanos) {
           cpuRanges[range.mNestingLevel].emplace_back(range.mName,
-              (range.mCPUStart - cpuFrameStart) / 1000, (range.mCPUEnd - cpuFrameStart) / 1000);
+              static_cast<uint32_t>(range.mCPUStart - cpuFrameStart) / 1000,
+              static_cast<uint32_t>(range.mCPUEnd - cpuFrameStart) / 1000);
         }
       }
     }

--- a/plugins/csp-timings/src/Plugin.hpp
+++ b/plugins/csp-timings/src/Plugin.hpp
@@ -17,7 +17,7 @@
 namespace csp::timings {
 
 /// A plugin which uses the built-in timer queries of CosmoScout VR to draw on-screen live frame
-/// timing statistics. This plugin can also be used to export recorded time series to a CSV file.
+/// timing statistics. This plugin can also be used to export recorded time series to CSV files.
 class Plugin : public cs::core::PluginBase {
  public:
   void init() override;
@@ -25,12 +25,32 @@ class Plugin : public cs::core::PluginBase {
   void update() override;
 
  private:
+  struct Range {
+    Range(std::string name, uint32_t start, uint32_t end)
+        : mName(std::move(name))
+        , mStart(start)
+        , mEnd(end) {
+    }
+
+    std::string mName;
+
+    // Frame-relative timestamps in microseconds.
+    uint32_t mStart;
+    uint32_t mEnd;
+  };
+
   /// This store the statistics GUI element.
   std::unique_ptr<cs::gui::GuiItem> mGuiItem;
 
   bool mEnableRecording  = false;
   bool mEnableStatistics = false;
-  std::list<std::unordered_map<std::string, cs::utils::FrameTimings::QueryResult>> mRecordedTimings;
+
+  /// Stores recorded ranges for the GPU and CPU for each frame for each nesting level. So the
+  /// outer-most vector is per recorded frame, the middle per range nesting level and the inner-most
+  /// contains all ranges for the specific level.
+  /// Frame Indices | Nesting Levels | Ranges
+  std::vector<std::vector<std::vector<Range>>> mRecordedGPURanges;
+  std::vector<std::vector<std::vector<Range>>> mRecordedCPURanges;
 
   int mFrameTimingConnection;
 };

--- a/src/cosmoscout/Application.cpp
+++ b/src/cosmoscout/Application.cpp
@@ -448,21 +448,21 @@ void Application::FrameUpdate() {
     // Update the InputManager.
     {
       cs::utils::FrameTimings::ScopedTimer timer(
-          "InputManager Update", cs::utils::FrameTimings::QueryMode::eCPU);
+          "Update InputManager", cs::utils::FrameTimings::QueryMode::eCPU);
       mInputManager->update();
     }
 
     // Update the TimeControl.
     {
       cs::utils::FrameTimings::ScopedTimer timer(
-          "TimeControl Update", cs::utils::FrameTimings::QueryMode::eCPU);
+          "Update TimeControl", cs::utils::FrameTimings::QueryMode::eCPU);
       mTimeControl->update();
     }
 
     // Update the navigation, SolarSystem and scene scale.
     {
       cs::utils::FrameTimings::ScopedTimer timer(
-          "SolarSystem Update", cs::utils::FrameTimings::QueryMode::eCPU);
+          "Update SolarSystem", cs::utils::FrameTimings::QueryMode::eCPU);
 
       // It may be that our observer is in a SPICE frame we do not have data for. If this is the
       // case, this call will bring it back to Solar System Barycenter / J2000 which should be
@@ -504,7 +504,7 @@ void Application::FrameUpdate() {
     // Update the individual plugins.
     for (auto const& plugin : mPlugins) {
       cs::utils::FrameTimings::ScopedTimer timer(
-          plugin.first, cs::utils::FrameTimings::QueryMode::eBoth);
+          "Update " + plugin.first, cs::utils::FrameTimings::QueryMode::eBoth);
 
       try {
         plugin.second.mPlugin->update();
@@ -554,12 +554,15 @@ void Application::FrameUpdate() {
     }
 
     // Update the GraphicsEngine.
-    mGraphicsEngine->update(glm::normalize(mSolarSystem->pSunPosition.get()));
+    {
+      cs::utils::FrameTimings::ScopedTimer timer("Update Graphics Engine");
+      mGraphicsEngine->update(glm::normalize(mSolarSystem->pSunPosition.get()));
+    }
   }
 
   // Update the user interface.
   {
-    cs::utils::FrameTimings::ScopedTimer timer("User Interface");
+    cs::utils::FrameTimings::ScopedTimer timer("Update User Interface");
 
     // Call update on all APIs
     if (mLoadedAllPlugins) {
@@ -617,7 +620,7 @@ void Application::FrameUpdate() {
   // update vista classes --------------------------------------------------------------------------
 
   {
-    cs::utils::FrameTimings::ScopedTimer timer("DisplayManager DrawFrame");
+    cs::utils::FrameTimings::ScopedTimer timer("Rendering");
     m_pDisplayManager->DrawFrame();
   }
 
@@ -631,7 +634,7 @@ void Application::FrameUpdate() {
   mFrameTimings->endFullFrameTiming();
 
   {
-    cs::utils::FrameTimings::ScopedTimer timer("DisplayManager DisplayFrame");
+    cs::utils::FrameTimings::ScopedTimer timer("Display Frame");
     m_pDisplayManager->DisplayFrame();
   }
 

--- a/src/cosmoscout/Application.hpp
+++ b/src/cosmoscout/Application.hpp
@@ -173,7 +173,6 @@ class Application : public VistaFrameLoop {
   std::shared_ptr<cs::core::TimeControl>    mTimeControl;
   std::shared_ptr<cs::core::SolarSystem>    mSolarSystem;
   std::unique_ptr<cs::core::DragNavigation> mDragNavigation;
-  std::shared_ptr<cs::utils::FrameTimings>  mFrameTimings;
   std::map<std::string, Plugin>             mPlugins;
   std::unique_ptr<cs::utils::Downloader>    mDownloader;
   std::unique_ptr<IVistaClusterDataSync>    mSceneSync;

--- a/src/cs-core/GuiManager.cpp
+++ b/src/cs-core/GuiManager.cpp
@@ -34,10 +34,9 @@ namespace cs::core {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 GuiManager::GuiManager(std::shared_ptr<Settings> settings,
-    std::shared_ptr<InputManager> pInputManager, std::shared_ptr<utils::FrameTimings> pFrameTimings)
+    std::shared_ptr<InputManager> pInputManager)
     : mInputManager(std::move(pInputManager))
-    , mSettings(std::move(settings))
-    , mFrameTimings(std::move(pFrameTimings)) {
+    , mSettings(std::move(settings)) {
 
   // Tell the user what's going on.
   logger().debug("Creating GuiManager.");

--- a/src/cs-core/GuiManager.cpp
+++ b/src/cs-core/GuiManager.cpp
@@ -33,8 +33,8 @@ namespace cs::core {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-GuiManager::GuiManager(std::shared_ptr<Settings> settings,
-    std::shared_ptr<InputManager> pInputManager)
+GuiManager::GuiManager(
+    std::shared_ptr<Settings> settings, std::shared_ptr<InputManager> pInputManager)
     : mInputManager(std::move(pInputManager))
     , mSettings(std::move(settings)) {
 

--- a/src/cs-core/GuiManager.hpp
+++ b/src/cs-core/GuiManager.hpp
@@ -215,8 +215,8 @@ class CS_CORE_EXPORT GuiManager {
   void onLoad();
   void onSave();
 
-  std::shared_ptr<InputManager>        mInputManager;
-  std::shared_ptr<Settings>            mSettings;
+  std::shared_ptr<InputManager> mInputManager;
+  std::shared_ptr<Settings>     mSettings;
 
   std::unique_ptr<VistaViewportResizeToProjectionAdapter> mViewportUpdater;
   std::unique_ptr<gui::WorldSpaceGuiArea>                 mGlobalGuiArea;

--- a/src/cs-core/GuiManager.hpp
+++ b/src/cs-core/GuiManager.hpp
@@ -27,10 +27,6 @@ class VistaOpenGLNode;
 class VistaViewportResizeToProjectionAdapter;
 class VistaTransformNode;
 
-namespace cs::utils {
-class FrameTimings;
-} // namespace cs::utils
-
 namespace cs::core {
 class Settings;
 class InputManager;
@@ -60,8 +56,7 @@ class InputManager;
 /// instance is then passed to all plugins.
 class CS_CORE_EXPORT GuiManager {
  public:
-  GuiManager(std::shared_ptr<Settings> settings, std::shared_ptr<InputManager> pInputManager,
-      std::shared_ptr<utils::FrameTimings> pFrameTimings);
+  GuiManager(std::shared_ptr<Settings> settings, std::shared_ptr<InputManager> pInputManager);
 
   GuiManager(GuiManager const& other) = delete;
   GuiManager(GuiManager&& other)      = delete;
@@ -222,7 +217,6 @@ class CS_CORE_EXPORT GuiManager {
 
   std::shared_ptr<InputManager>        mInputManager;
   std::shared_ptr<Settings>            mSettings;
-  std::shared_ptr<utils::FrameTimings> mFrameTimings;
 
   std::unique_ptr<VistaViewportResizeToProjectionAdapter> mViewportUpdater;
   std::unique_ptr<gui::WorldSpaceGuiArea>                 mGlobalGuiArea;

--- a/src/cs-core/PluginBase.cpp
+++ b/src/cs-core/PluginBase.cpp
@@ -13,8 +13,7 @@ namespace cs::core {
 void PluginBase::setAPI(std::shared_ptr<Settings> settings,
     std::shared_ptr<SolarSystem> solarSystem, std::shared_ptr<GuiManager> guiManager,
     std::shared_ptr<InputManager> inputManager, VistaSceneGraph* sceneGraph,
-    std::shared_ptr<GraphicsEngine>      graphicsEngine,
-    std::shared_ptr<utils::FrameTimings> frameTimings, std::shared_ptr<TimeControl> timeControl) {
+    std::shared_ptr<GraphicsEngine> graphicsEngine, std::shared_ptr<TimeControl> timeControl) {
 
   mAllSettings    = std::move(settings);
   mSolarSystem    = std::move(solarSystem);
@@ -22,7 +21,6 @@ void PluginBase::setAPI(std::shared_ptr<Settings> settings,
   mGuiManager     = std::move(guiManager);
   mGraphicsEngine = std::move(graphicsEngine);
   mInputManager   = std::move(inputManager);
-  mFrameTimings   = std::move(frameTimings);
   mTimeControl    = std::move(timeControl);
 }
 

--- a/src/cs-core/PluginBase.hpp
+++ b/src/cs-core/PluginBase.hpp
@@ -19,10 +19,6 @@
 
 class VistaSceneGraph;
 
-namespace cs::utils {
-class FrameTimings;
-}
-
 namespace cs::core {
 class GraphicsEngine;
 class GuiManager;
@@ -53,7 +49,7 @@ class CS_CORE_EXPORT PluginBase {
   void setAPI(std::shared_ptr<Settings> settings, std::shared_ptr<SolarSystem> solarSystem,
       std::shared_ptr<GuiManager> guiManager, std::shared_ptr<InputManager> inputManager,
       VistaSceneGraph* sceneGraph, std::shared_ptr<GraphicsEngine> graphicsEngine,
-      std::shared_ptr<utils::FrameTimings> frameTimings, std::shared_ptr<TimeControl> timeControl);
+      std::shared_ptr<TimeControl> timeControl);
 
   /// Override this function to initialize your plugin. It will be called directly after
   /// application startup and before the update loop starts.
@@ -68,14 +64,13 @@ class CS_CORE_EXPORT PluginBase {
   virtual void update(){};
 
  protected:
-  std::shared_ptr<Settings>            mAllSettings;
-  std::shared_ptr<SolarSystem>         mSolarSystem;
-  VistaSceneGraph*                     mSceneGraph{};
-  std::shared_ptr<GuiManager>          mGuiManager;
-  std::shared_ptr<GraphicsEngine>      mGraphicsEngine;
-  std::shared_ptr<InputManager>        mInputManager;
-  std::shared_ptr<utils::FrameTimings> mFrameTimings;
-  std::shared_ptr<TimeControl>         mTimeControl;
+  std::shared_ptr<Settings>       mAllSettings;
+  std::shared_ptr<SolarSystem>    mSolarSystem;
+  VistaSceneGraph*                mSceneGraph{};
+  std::shared_ptr<GuiManager>     mGuiManager;
+  std::shared_ptr<GraphicsEngine> mGraphicsEngine;
+  std::shared_ptr<InputManager>   mInputManager;
+  std::shared_ptr<TimeControl>    mTimeControl;
 };
 
 } // namespace cs::core

--- a/src/cs-core/SolarSystem.cpp
+++ b/src/cs-core/SolarSystem.cpp
@@ -31,10 +31,8 @@ namespace cs::core {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 SolarSystem::SolarSystem(std::shared_ptr<Settings> settings,
-    std::shared_ptr<utils::FrameTimings>           frameTimings,
     std::shared_ptr<GraphicsEngine> graphicsEngine, std::shared_ptr<TimeControl> timeControl)
     : mSettings(std::move(settings))
-    , mFrameTimings(std::move(frameTimings))
     , mGraphicsEngine(std::move(graphicsEngine))
     , mTimeControl(std::move(timeControl))
     , mSun(std::make_shared<scene::CelestialObject>()) {

--- a/src/cs-core/SolarSystem.hpp
+++ b/src/cs-core/SolarSystem.hpp
@@ -44,8 +44,8 @@ class CS_CORE_EXPORT SolarSystem {
   /// Current position of the sun, relative to the observer.
   utils::Property<glm::dvec3> pSunPosition = glm::dvec3(0.F);
 
-  SolarSystem(std::shared_ptr<Settings> settings, 
-      std::shared_ptr<GraphicsEngine> graphicsEngine, std::shared_ptr<TimeControl> timeControl);
+  SolarSystem(std::shared_ptr<Settings> settings, std::shared_ptr<GraphicsEngine> graphicsEngine,
+      std::shared_ptr<TimeControl> timeControl);
 
   SolarSystem(SolarSystem const& other) = delete;
   SolarSystem(SolarSystem&& other)      = delete;

--- a/src/cs-core/SolarSystem.hpp
+++ b/src/cs-core/SolarSystem.hpp
@@ -18,10 +18,6 @@
 #include <unordered_set>
 #include <vector>
 
-namespace cs::utils {
-class FrameTimings;
-} // namespace cs::utils
-
 namespace cs::core {
 
 class Settings;
@@ -48,7 +44,7 @@ class CS_CORE_EXPORT SolarSystem {
   /// Current position of the sun, relative to the observer.
   utils::Property<glm::dvec3> pSunPosition = glm::dvec3(0.F);
 
-  SolarSystem(std::shared_ptr<Settings> settings, std::shared_ptr<utils::FrameTimings> frameTimings,
+  SolarSystem(std::shared_ptr<Settings> settings, 
       std::shared_ptr<GraphicsEngine> graphicsEngine, std::shared_ptr<TimeControl> timeControl);
 
   SolarSystem(SolarSystem const& other) = delete;
@@ -235,7 +231,6 @@ class CS_CORE_EXPORT SolarSystem {
 
  private:
   std::shared_ptr<Settings>                         mSettings;
-  std::shared_ptr<utils::FrameTimings>              mFrameTimings;
   std::shared_ptr<GraphicsEngine>                   mGraphicsEngine;
   std::shared_ptr<TimeControl>                      mTimeControl;
   scene::CelestialObserver                          mObserver;

--- a/src/cs-graphics/GlareMipMap.cpp
+++ b/src/cs-graphics/GlareMipMap.cpp
@@ -6,6 +6,7 @@
 
 #include "GlareMipMap.hpp"
 
+#include "../cs-utils/FrameTimings.hpp"
 #include "logger.hpp"
 
 #include <algorithm>
@@ -303,6 +304,8 @@ GlareMipMap::~GlareMipMap() {
 
 void GlareMipMap::update(
     VistaTexture* hdrBufferComposite, HDRBuffer::GlareMode glareMode, uint32_t glareQuality) {
+
+  utils::FrameTimings::ScopedTimer timer("Compute Glare");
 
   if (mComputeProgram == 0 || glareMode != mLastGlareMode || glareQuality != mLastGlareQuality) {
 

--- a/src/cs-graphics/LuminanceMipMap.cpp
+++ b/src/cs-graphics/LuminanceMipMap.cpp
@@ -6,6 +6,8 @@
 
 #include "LuminanceMipMap.hpp"
 
+#include "../cs-utils/FrameTimings.hpp"
+
 #include <algorithm>
 #include <cmath>
 #include <iostream>
@@ -176,6 +178,8 @@ LuminanceMipMap::~LuminanceMipMap() {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 void LuminanceMipMap::update(VistaTexture* hdrBufferComposite) {
+
+  utils::FrameTimings::ScopedTimer timer("Compute Scene Luminance");
 
   // Read the luminance values from the last frame. ------------------------------------------------
   glBindBuffer(GL_PIXEL_PACK_BUFFER, mPBO);

--- a/src/cs-graphics/ToneMappingNode.cpp
+++ b/src/cs-graphics/ToneMappingNode.cpp
@@ -6,8 +6,8 @@
 
 #include "ToneMappingNode.hpp"
 
-#include "HDRBuffer.hpp"
 #include "../cs-utils/FrameTimings.hpp"
+#include "HDRBuffer.hpp"
 
 #include <VistaInterProcComm/Cluster/VistaClusterDataCollect.h>
 #include <VistaInterProcComm/Cluster/VistaClusterDataSync.h>

--- a/src/cs-graphics/ToneMappingNode.cpp
+++ b/src/cs-graphics/ToneMappingNode.cpp
@@ -7,6 +7,7 @@
 #include "ToneMappingNode.hpp"
 
 #include "HDRBuffer.hpp"
+#include "../cs-utils/FrameTimings.hpp"
 
 #include <VistaInterProcComm/Cluster/VistaClusterDataCollect.h>
 #include <VistaInterProcComm/Cluster/VistaClusterDataSync.h>
@@ -439,6 +440,8 @@ float ToneMappingNode::getLastMaximumLuminance() const {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 bool ToneMappingNode::ToneMappingNode::Do() {
+
+  utils::FrameTimings::ScopedTimer timer("Tonemapping");
 
   if (mShaderDirty) {
 

--- a/src/cs-utils/FrameTimings.cpp
+++ b/src/cs-utils/FrameTimings.cpp
@@ -164,7 +164,7 @@ int32_t TimerPool::startRange(std::string name, FrameTimings::QueryMode mode) {
   mRanges.push_back(std::move(range));
 
   // Return the index at which this range was inserted.
-  return mRanges.size() - 1;
+  return static_cast<int32_t>(mRanges.size() - 1);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/cs-utils/FrameTimings.cpp
+++ b/src/cs-utils/FrameTimings.cpp
@@ -16,252 +16,227 @@ namespace cs::utils {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-namespace {
-int                                            s_iCurrentInstance = 0;
-std::array<std::shared_ptr<TimerQueryPool>, 2> s_pTimerQueryPoolInstances{};
-std::string                                    s_sLastRangeKey{};
-} // namespace
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
 FrameTimings::ScopedTimer::ScopedTimer(std::string name, QueryMode mode)
-    : mName(std::move(name)) {
-  FrameTimings::start(mName, mode);
+    : mID(FrameTimings::get().startRange(std::move(name), mode)) {
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 FrameTimings::ScopedTimer::~ScopedTimer() {
-  try {
-    FrameTimings::end(mName);
-  } catch (...) {}
+  FrameTimings::get().endRange(mID);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-void FrameTimings::start(std::string const& name, QueryMode mode) {
-  if (s_pTimerQueryPoolInstances.at(s_iCurrentInstance)) {
-    s_pTimerQueryPoolInstances.at(s_iCurrentInstance)->start(name, mode);
-    s_sLastRangeKey = name;
-  }
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-void FrameTimings::end(std::string const& name) {
-  if (s_pTimerQueryPoolInstances.at(s_iCurrentInstance)) {
-    s_pTimerQueryPoolInstances.at(s_iCurrentInstance)->end(name);
-  }
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-void FrameTimings::end() {
-  if (s_pTimerQueryPoolInstances.at(s_iCurrentInstance)) {
-    s_pTimerQueryPoolInstances.at(s_iCurrentInstance)->end(s_sLastRangeKey);
-  }
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-std::unordered_map<std::string, FrameTimings::QueryResult>
-FrameTimings::getCalculatedQueryResults() const {
-  std::unordered_map<std::string, QueryResult> result;
-
-  if (!s_pTimerQueryPoolInstances.at(s_iCurrentInstance)) {
-    return result;
-  }
-
-  if (pEnableMeasurements.get()) {
-    for (auto const& ranges :
-        s_pTimerQueryPoolInstances.at(s_iCurrentInstance)->getQueryResults()) {
-      uint64_t timeGPU(0);
-      uint64_t timeCPU(0);
-      for (auto const& range : ranges.second) {
-        timeGPU += range.mGPUTime;
-        timeCPU += range.mCPUTime;
-      }
-
-      result[ranges.first] = {timeGPU, timeCPU};
-    }
-  }
-
-  return result;
+FrameTimings& FrameTimings::get() {
+  static FrameTimings instance;
+  return instance;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 FrameTimings::FrameTimings() {
-  std::size_t const maxNRofTimings = 512;
-  pEnableMeasurements.connect([maxNRofTimings](bool enable) {
-    if (enable) {
-      s_pTimerQueryPoolInstances[0] = std::make_shared<TimerQueryPool>(maxNRofTimings);
-      s_pTimerQueryPoolInstances[1] = std::make_shared<TimerQueryPool>(maxNRofTimings);
-    } else {
-      s_pTimerQueryPoolInstances[0] = nullptr;
-      s_pTimerQueryPoolInstances[1] = nullptr;
+  pEnableMeasurements.connectAndTouch([this](bool enable) {
+    for (auto& pool : mTimerPools) {
+      if (enable) {
+        pool = std::make_unique<TimerPool>(512);
+      } else {
+        // If measurements are disabled, we need at most two query objects, one for the start of the
+        // full frame timing and one for the end of the full frame timing.
+        pool = std::make_unique<TimerPool>(2);
+      }
     }
   });
-  mFullFrameTimerPools[0] = std::make_shared<TimerQueryPool>(2);
-  mFullFrameTimerPools[1] = std::make_shared<TimerQueryPool>(2);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-void FrameTimings::startFullFrameTiming() {
-  mFullFrameTimerPools.at(mCurrentIndex)->start("FullFrame", FrameTimings::QueryMode::eBoth);
-}
+void FrameTimings::startFrame() {
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
+  // Advance the timer pool triple-buffer by one.
+  mCurrentPool = (mCurrentPool + 1) % mTimerPools.size();
 
-void FrameTimings::endFullFrameTiming() {
-  mFullFrameTimerPools.at(mCurrentIndex)->end("FullFrame");
-  mCurrentIndex = (mCurrentIndex + 1) % 2;
-  mFullFrameTimerPools.at(mCurrentIndex)->calculateQueryResults();
+  // Fetch the query results for the oldest pool in our triple buffer. From this the getRanges()
+  // call will read this frame.
+  auto oldestPool = (mCurrentPool + 1) % mTimerPools.size();
+  mTimerPools.at(oldestPool)->fetchQueries();
 
-  double const epsilon      = 0.000001;
-  auto         queryResults = mFullFrameTimerPools.at(mCurrentIndex)->getQueryResults();
-  if (!queryResults.empty() && !queryResults.begin()->second.empty()) {
-    pFrameTime = std::max(queryResults.begin()->second[0].mGPUTime * epsilon,
-        queryResults.begin()->second[0].mCPUTime * epsilon);
-  }
-}
+  // Retrieve the pFrameTime from the oldest pool as well.
+  double const toMilliSeconds = 0.000001;
+  auto const&  ranges         = mTimerPools.at(oldestPool)->getRanges();
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-void FrameTimings::update() const {
-  s_iCurrentInstance = (s_iCurrentInstance + 1) % 2;
-
-  if (!s_pTimerQueryPoolInstances.at(s_iCurrentInstance)) {
-    return;
+  if (!ranges.empty()) {
+    auto gpuTime = (ranges[0].mGPUEnd - ranges[0].mGPUStart) * toMilliSeconds;
+    auto cpuTime = (ranges[0].mCPUEnd - ranges[0].mCPUStart) * toMilliSeconds;
+    pFrameTime   = std::max(gpuTime, cpuTime);
   }
 
+  // Reset the new current pool.
+  auto const& pool = mTimerPools.at(mCurrentPool);
+  pool->reset();
+
+  // Start the "root" full frame timing. This is always done, even if pEnableMeasurements is set to
+  // false. This is required to get data for the pFrameTime property.
+  mFullFrameTimingID = pool->startRange("Process Frame", FrameTimings::QueryMode::eBoth);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+void FrameTimings::endFrame() {
+
+  // End the "root" full frame timing. This is always done, even if pEnableMeasurements is set to
+  // false. This is required to get data for the pFrameTime property.
+  mTimerPools.at(mCurrentPool)->endRange(mFullFrameTimingID);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+int32_t FrameTimings::startRange(std::string name, QueryMode mode) {
+
+  // Only attempt to start the timing if pEnableMeasurements is set to true.
   if (pEnableMeasurements.get()) {
-    s_pTimerQueryPoolInstances.at(s_iCurrentInstance)->calculateQueryResults();
+    return mTimerPools.at(mCurrentPool)->startRange(std::move(name), mode);
+  }
+
+  return -1;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+void FrameTimings::endRange(int32_t id) {
+
+  // Only attempt to end the timing if pEnableMeasurements is set to true.
+  if (pEnableMeasurements.get()) {
+    mTimerPools.at(mCurrentPool)->endRange(id);
   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-TimerQueryPool::TimerQueryPool(std::size_t max_size)
-    : mMaxSize(max_size)
-    , mQueries(max_size, 0)
-    , mTimestamps(max_size, 0)
-    , mQueryDone(0)
-    , mIndex(0) {
-  glGenQueries(static_cast<GLsizei>(max_size), mQueries.data());
+std::vector<FrameTimings::Range> const& FrameTimings::getRanges() {
+
+  // We return the ranges from the last-but-one frame.
+  auto oldestPool = (mCurrentPool + 1) % mTimerPools.size();
+  return mTimerPools.at(oldestPool)->getRanges();
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-void TimerQueryPool::start(std::string const& name, FrameTimings::QueryMode mode) {
-  QueryRange range;
-  range.mMode = mode;
+TimerPool::TimerPool(std::size_t queryAllocationBucketSize)
+    : mQueryAllocationBucketSize(queryAllocationBucketSize)
+    , mQueries(queryAllocationBucketSize, 0) {
+  glGenQueries(static_cast<GLsizei>(queryAllocationBucketSize), mQueries.data());
+}
 
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+TimerPool::~TimerPool() {
+  glDeleteQueries(static_cast<GLsizei>(mQueries.size()), mQueries.data());
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+void TimerPool::reset() {
+  mNextQueryID         = 0;
+  mCurrentNestingLevel = 0;
+  mRanges.clear();
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+int32_t TimerPool::startRange(std::string name, FrameTimings::QueryMode mode) {
+
+  FrameTimings::Range range;
+  range.mMode         = mode;
+  range.mName         = std::move(name);
+  range.mNestingLevel = mCurrentNestingLevel++;
+
+  // Start the GPU range if necessary.
   if (mode == FrameTimings::QueryMode::eGPU || mode == FrameTimings::QueryMode::eBoth) {
-    auto t = timestamp();
-    if (t) {
-      range.mGPUStart = *t;
-    } else {
-      logger().warn(
-          "Failed to start timer query: No more Timestamps available (mMaxSize={}, mIndex={})!",
-          mMaxSize, mIndex);
-    }
+    range.mStartQueryIndex = startTimerQuery();
   }
 
+  // Start the CPU range if necessary.
   if (mode == FrameTimings::QueryMode::eCPU || mode == FrameTimings::QueryMode::eBoth) {
-    auto now        = std::chrono::high_resolution_clock::now();
-    range.mCPUStart = now;
+    range.mCPUStart = std::chrono::high_resolution_clock::now().time_since_epoch().count();
   }
 
-  mQueryRanges[name].push_back(range);
+  mRanges.push_back(std::move(range));
+
+  // Return the index at which this range was inserted.
+  return mRanges.size() - 1;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-void TimerQueryPool::end(std::string const& name) {
-  if (mQueryRanges.empty()) {
+void TimerPool::endRange(int32_t id) {
+
+  // Abort if no valid ID was given.
+  if (id < 0 || id >= static_cast<int32_t>(mRanges.size())) {
     return;
   }
 
-  auto iter = mQueryRanges.find(name);
-  if (iter == mQueryRanges.end()) {
-    logger().warn("Failed to end timer query: Unknown key '{}'!", name);
-    return;
+  // End the GPU range if necessary.
+  if (mRanges[id].mMode == FrameTimings::QueryMode::eGPU ||
+      mRanges[id].mMode == FrameTimings::QueryMode::eBoth) {
+    mRanges[id].mEndQueryIndex = startTimerQuery();
   }
 
-  auto& range = iter->second.back();
-  if (range.mMode == FrameTimings::QueryMode::eGPU ||
-      range.mMode == FrameTimings::QueryMode::eBoth) {
-    auto t = timestamp();
-    if (t) {
-      range.mGPUEnd = *t;
-    } else {
-      logger().warn("Failed to end timer query: No more Timestamps available!");
-    }
+  // End the CPU range if necessary.
+  if (mRanges[id].mMode == FrameTimings::QueryMode::eCPU ||
+      mRanges[id].mMode == FrameTimings::QueryMode::eBoth) {
+    mRanges[id].mCPUEnd = std::chrono::high_resolution_clock::now().time_since_epoch().count();
   }
 
-  if (range.mMode == FrameTimings::QueryMode::eCPU ||
-      range.mMode == FrameTimings::QueryMode::eBoth) {
-    range.mCPUEnd = std::chrono::high_resolution_clock::now();
-  }
+  --mCurrentNestingLevel;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-std::optional<std::size_t> TimerQueryPool::timestamp() {
-  if (mIndex < mMaxSize) {
-    glQueryCounter(mQueries[mIndex], GL_TIMESTAMP);
-    std::size_t inserted_at = mIndex;
-    ++mIndex;
-    return inserted_at;
-  }
-  return std::nullopt;
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-void TimerQueryPool::calculateQueryResults() {
-  // Fetch timestamps from gpu and calculate time diffs.
-  if (mIndex == 0) {
+void TimerPool::fetchQueries() {
+  // No query has been issued, so nothing to update.
+  if (mNextQueryID == 0) {
     return;
   }
 
-  mQueryDone = 0;
-
-  // Wait for queries to finish.
-  while (!mQueryDone) {
-    glGetQueryObjectiv(mQueries[mIndex - 1], GL_QUERY_RESULT_AVAILABLE, &mQueryDone);
+  // Wait for the last query to finish.
+  int32_t queriesDone = 0;
+  while (!queriesDone) {
+    glGetQueryObjectiv(mQueries[mNextQueryID - 1], GL_QUERY_RESULT_AVAILABLE, &queriesDone);
   }
 
   // Get the query results.
-  for (std::size_t i = 0; i < mIndex; ++i) {
-    glGetQueryObjectui64v(mQueries[i], GL_QUERY_RESULT, &mTimestamps[i]);
+  std::vector<uint64_t> queryResults(mNextQueryID);
+  for (std::size_t i = 0; i < mNextQueryID; ++i) {
+    glGetQueryObjectui64v(mQueries[i], GL_QUERY_RESULT, &queryResults[i]);
   }
 
-  mQueryResults.clear();
-
-  for (auto& pair : mQueryRanges) {
-    for (auto& range : pair.second) {
-      FrameTimings::QueryResult result;
-      result.mGPUTime = mTimestamps[range.mGPUEnd] - mTimestamps[range.mGPUStart];
-      result.mCPUTime = static_cast<uint64_t>(
-          std::chrono::duration_cast<std::chrono::nanoseconds>(range.mCPUEnd - range.mCPUStart)
-              .count());
-      mQueryResults[pair.first].push_back(result);
+  for (std::size_t i = 0; i < mRanges.size(); ++i) {
+    if (mRanges[i].mMode == FrameTimings::QueryMode::eGPU ||
+        mRanges[i].mMode == FrameTimings::QueryMode::eBoth) {
+      mRanges[i].mGPUStart = queryResults[mRanges[i].mStartQueryIndex];
+      mRanges[i].mGPUEnd   = queryResults[mRanges[i].mEndQueryIndex];
     }
   }
-
-  // Reset index.
-  mIndex = 0;
-  mQueryRanges.clear();
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-std::unordered_map<std::string, std::vector<FrameTimings::QueryResult>> const&
-TimerQueryPool::getQueryResults() const {
-  return mQueryResults;
+std::vector<FrameTimings::Range> const& TimerPool::getRanges() const {
+  return mRanges;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+std::size_t TimerPool::startTimerQuery() {
+  if (mNextQueryID >= mQueries.size()) {
+    auto currentSize = mQueries.size();
+    mQueries.resize(currentSize + mQueryAllocationBucketSize, 0);
+    glGenQueries(static_cast<GLsizei>(mQueryAllocationBucketSize), mQueries.data() + currentSize);
+  }
+
+  glQueryCounter(mQueries[mNextQueryID], GL_TIMESTAMP);
+  return mNextQueryID++;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This PR significantly improves the frame timing capabilities of CosmoScout VR. Here are the changes:
* The `FrameTimings` now keep track of the number of currently active ranges. This allows us to determine the current nesting level of a timing range.
* The statistics UI element now shows the ranges as they were recorded for the last-but-one frame with the appropriate nesting level. There are tooltips for detailed information.
* A triple buffer is used for the timer queries, which improves performance.
* The recording-to-file has been adapted accordingly. It now creates a set of files, one for each nesting level per CPU or GPU.
* The `FrameTimings` class is now a real singleton, before it used some hidden static variables.

![Screenshot from 2021-02-24 13-42-39](https://user-images.githubusercontent.com/829942/109126867-0e89d300-774e-11eb-9bf6-f8d93aa19ba5.png)
