### PR TITLE
Bookmark fixes

### DIFF
--- a/plugins/csp-fly-to-locations/src/Plugin.cpp
+++ b/plugins/csp-fly-to-locations/src/Plugin.cpp
@@ -60,14 +60,15 @@ void Plugin::init() {
         mGuiManager->getGui()->callJavascript(
             "CosmoScout.gui.clearHtml", "flytolocations-bookmarks-list");
 
+        // If no body is set, we are in free space.
+        std::string center = body ? body->getCenterName() : "Solar System Barycenter";
+
         // Add all list-bookmarks for this body.
-        if (body) {
-          for (auto const& [id, bookmark] : mGuiManager->getBookmarks()) {
-            if (bookmark.mLocation && bookmark.mLocation.value().mPosition) {
-              if (body->getCenterName() == bookmark.mLocation.value().mCenter) {
-                mGuiManager->getGui()->callJavascript("CosmoScout.flyToLocations.addListBookmark",
-                    id, bookmark.mName, bookmark.mTime.has_value());
-              }
+        for (auto const& [id, bookmark] : mGuiManager->getBookmarks()) {
+          if (bookmark.mLocation && bookmark.mLocation.value().mPosition) {
+            if (center == bookmark.mLocation.value().mCenter) {
+              mGuiManager->getGui()->callJavascript("CosmoScout.flyToLocations.addListBookmark", id,
+                  bookmark.mName, bookmark.mTime.has_value());
             }
           }
         }
@@ -111,8 +112,7 @@ void Plugin::onAddBookmark(uint32_t bookmarkID, cs::core::Settings::Bookmark con
           bookmark.mName, bookmark.mIcon.value());
     } else {
       // Add all other bookmars to the list, if they are relevant for the current body.
-      if (mSolarSystem->pActiveBody.get() != nullptr &&
-          mSolarSystem->pActiveBody.get()->getCenterName() == bookmark.mLocation.value().mCenter) {
+      if (mSolarSystem->getObserver().getCenterName() == bookmark.mLocation.value().mCenter) {
         mGuiManager->getGui()->callJavascript("CosmoScout.flyToLocations.addListBookmark",
             bookmarkID, bookmark.mName, bookmark.mTime.has_value());
       }

--- a/plugins/csp-minimap/src/Plugin.cpp
+++ b/plugins/csp-minimap/src/Plugin.cpp
@@ -191,7 +191,7 @@ void Plugin::onAddBookmark(std::shared_ptr<cs::scene::CelestialBody> const& acti
 
   // Add only if it has a location and matches the currently active body.
   if (bookmark.mLocation && bookmark.mLocation.value().mPosition) {
-    if (activeBody->getCenterName() == bookmark.mLocation.value().mCenter) {
+    if (activeBody && activeBody->getCenterName() == bookmark.mLocation.value().mCenter) {
       auto radii = activeBody->getRadii();
       auto p     = cs::utils::convert::cartesianToLngLat(
           bookmark.mLocation.value().mPosition.value(), radii);

--- a/resources/gui/js/apis/bookmark_editor.js
+++ b/resources/gui/js/apis/bookmark_editor.js
@@ -106,10 +106,10 @@ class BookmarkEditorApi extends IApi {
     };
 
     document.querySelector("#bookmark-editor-rotation-w + div > button").onclick = () => {
-      this._rotationXDiv.value = CosmoScout.state.observerRotation[1];
-      this._rotationYDiv.value = CosmoScout.state.observerRotation[2];
-      this._rotationZDiv.value = CosmoScout.state.observerRotation[3];
-      this._rotationWDiv.value = CosmoScout.state.observerRotation[0];
+      this._rotationXDiv.value = CosmoScout.state.observerRotation[0];
+      this._rotationYDiv.value = CosmoScout.state.observerRotation[1];
+      this._rotationZDiv.value = CosmoScout.state.observerRotation[2];
+      this._rotationWDiv.value = CosmoScout.state.observerRotation[3];
     };
 
     // Initialize Icon Select Popover --------------------------------------------------------------

--- a/src/cosmoscout/Application.cpp
+++ b/src/cosmoscout/Application.cpp
@@ -843,14 +843,19 @@ void Application::connectSlots() {
   // Show notification when the center name of the celestial observer changes.
   mSolarSystem->pActiveBody.connectAndTouch(
       [this](std::shared_ptr<cs::scene::CelestialBody> const& body) {
-        if (body) {
-          mGuiManager->getGui()->executeJavascript(
-              fmt::format("CosmoScout.state.activePlanetCenter = '{}';", body->getCenterName()));
+        std::string center = "Solar System Barycenter";
+        glm::dvec3  radii(0.0);
 
-          auto radii = body->getRadii();
-          mGuiManager->getGui()->executeJavascript(
-              fmt::format("CosmoScout.state.activePlanetRadius = [{}, {}];", radii[0], radii[1]));
+        if (body) {
+          center = body->getCenterName();
+          radii  = body->getRadii();
         }
+
+        mGuiManager->getGui()->executeJavascript(
+            fmt::format("CosmoScout.state.activePlanetCenter = '{}';", center));
+
+        mGuiManager->getGui()->executeJavascript(fmt::format(
+            "CosmoScout.state.activePlanetRadius = [{}, {}, {}];", radii[0], radii[1], radii[2]));
       });
 
   // Show notification when the frame name of the celestial observer changes.

--- a/src/cs-core/Settings.hpp
+++ b/src/cs-core/Settings.hpp
@@ -48,6 +48,10 @@ struct adl_serializer<glm::vec<C, T, Q>> {
 
 // A partial template specialization for serialization and deserialization of glm::*qua*. This
 // allows using glm's quaternion types as settings elements.
+// A very weird thing about glm is that it mixes the order of quaternion members. The constructor
+// expects qua(w, x, y, z), the accessor returns qua[0] = x, qua[1] = y, qua[2] = z, qua[3] = w.
+// In the settings of CosmoScout VR and in the user interface we always attempt to show w as the
+// last component.
 template <typename T, glm::qualifier Q>
 struct adl_serializer<glm::qua<T, Q>> {
   static void to_json(json& j, glm::qua<T, Q> const& opt) {

--- a/src/cs-core/SolarSystem.cpp
+++ b/src/cs-core/SolarSystem.cpp
@@ -395,14 +395,14 @@ void SolarSystem::updateObserverFrame() {
   }
 
   // If currently no observer animation is in progress, we change the pActiveBody accordingly. This
-  // may be null if we are very far awy from any object.
+  // may be null if we are very far away from any object.
   if (!mObserver.isAnimationInProgress()) {
     pActiveBody = activeBody;
 
     std::string sCenter = "Solar System Barycenter";
     std::string sFrame  = "J2000";
 
-    // We change frame and center if there is a object with weight larger than mLockWeight
+    // We change frame and center if there is an object with weight larger than mLockWeight
     // and mTrackWeight.
     if (activeBody) {
       if (dActiveWeight > mSettings->mSceneScale.mLockWeight) {

--- a/src/cs-core/SolarSystem.cpp
+++ b/src/cs-core/SolarSystem.cpp
@@ -377,7 +377,8 @@ void SolarSystem::updateObserverFrame() {
         dWeight *= 0.01;
       }
 
-      if (dWeight > dActiveWeight) {
+      if (dWeight > dActiveWeight && (dWeight > mSettings->mSceneScale.mLockWeight ||
+                                         dWeight > mSettings->mSceneScale.mTrackWeight)) {
         activeBody    = object;
         dActiveWeight = dWeight;
       }
@@ -393,13 +394,17 @@ void SolarSystem::updateObserverFrame() {
     }
   }
 
-  // We change frame and center if there is a object with weight larger than mLockWeight
-  // and mTrackWeight.
-  if (activeBody) {
-    if (!mObserver.isAnimationInProgress()) {
-      std::string sCenter = "Solar System Barycenter";
-      std::string sFrame  = "J2000";
+  // If currently no observer animation is in progress, we change the pActiveBody accordingly. This
+  // may be null if we are very far awy from any object.
+  if (!mObserver.isAnimationInProgress()) {
+    pActiveBody = activeBody;
 
+    std::string sCenter = "Solar System Barycenter";
+    std::string sFrame  = "J2000";
+
+    // We change frame and center if there is a object with weight larger than mLockWeight
+    // and mTrackWeight.
+    if (activeBody) {
       if (dActiveWeight > mSettings->mSceneScale.mLockWeight) {
         sFrame = activeBody->getFrameName();
       }
@@ -407,9 +412,9 @@ void SolarSystem::updateObserverFrame() {
       if (dActiveWeight > mSettings->mSceneScale.mTrackWeight) {
         sCenter = activeBody->getCenterName();
       }
+    }
 
-      pActiveBody = activeBody;
-
+    if (sCenter != mObserver.getCenterName() || sFrame != mObserver.getFrameName()) {
       mObserver.changeOrigin(sCenter, sFrame, mTimeControl->pSimulationTime.get());
     }
   }


### PR DESCRIPTION
This fixes the following:
* Bookmarks with orientation did not set the correct orientation.
* It wasn't possible to set bookmarks relative to the Solar System's Barycenter because Jupiter kept being the active body even if zoomed out very far.