### PR TITLE
Use forked version of libtiff

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "externals/libtiff"]
 	path = externals/libtiff
-	url = https://gitlab.com/libtiff/libtiff.git
+	url = https://github.com/cosmoscout/libtiff.git
 [submodule "externals/opensg-1.8"]
 	path = externals/opensg-1.8
 	url = https://github.com/cosmoscout/opensg-1.8.git

--- a/make_externals.bat
+++ b/make_externals.bat
@@ -181,7 +181,7 @@ echo Building and installing libtiff ...
 echo.
 
 cmake -E make_directory "%BUILD_DIR%/libtiff" && cd "%BUILD_DIR%/libtiff"
-cmake %CMAKE_FLAGS% -DCMAKE_INSTALL_PREFIX="%INSTALL_DIR%" -DCMAKE_UNITY_BUILD=%UNITY_BUILD%^
+cmake %CMAKE_FLAGS% -DCMAKE_INSTALL_PREFIX="%INSTALL_DIR%"^
       -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DBUILD_SHARED_LIBS=Off -DCMAKE_INSTALL_FULL_LIBDIR=lib^
       -Dzlib=Off -Dpixarlog=Off -Djpeg=Off -Dold-jpeg=Off -Djbig=Off -Dlzma=Off -Dzstd=Off^
       -DGLUT_INCLUDE_DIR=%INSTALL_DIR%/include^


### PR DESCRIPTION
As it happens occasionally that https://gitlab.com/libtiff/libtiff is not available, our CI builds sometimes stop working all of a sudden. To prevent this, we should use a forked version of libtiff.

For existing clones of CosmoScout VR, this may require
```
git submodule sync --recursive
git submodule update
```