### PR TITLE
Make tonemapping configurable

### DIFF
--- a/resources/gui/cosmoscout.html
+++ b/resources/gui/cosmoscout.html
@@ -195,7 +195,7 @@
                 <div class="section-header collapsed" id="headingSettings-Graphics"
                   data-toggle="collapse" data-target="#collapseSettings-Graphics"
                   aria-expanded="false" aria-controls="collapseSettings-Graphics" type="button">
-                  <i class="material-icons">trending_up</i>
+                  <i class="material-icons">brightness_medium</i>
                   <span>Graphics</span>
                   <i class="material-icons caret-icon">keyboard_arrow_left</i>
                 </div>
@@ -240,12 +240,161 @@
                     </div>
                   </div>
 
+                  <hr class="mt-2">
+
+                  <div class="row">
+                    <div class="col-7 offset-5">
+                      <label class="checklabel">
+                        <input type="checkbox" data-callback="graphics.setEnableLighting" />
+                        <i class="material-icons"></i>
+                        <span>Enable Lighting</span>
+                      </label>
+                    </div>
+                  </div>
+                  <div class="row">
+                    <div class="col-5">
+                      Quality
+                    </div>
+                    <div class="col-7">
+                      <div data-callback="graphics.setLightingQuality"></div>
+                    </div>
+                  </div>
+                  <div class="row">
+                    <div class="col-5">
+                      Ambient Light
+                    </div>
+                    <div class="col-7">
+                      <div data-callback="graphics.setAmbientLight">
+                      </div>
+                    </div>
+                  </div>
+
+                  <hr class="mt-2">
+
+                  <div class="row">
+                    <div class="col-7 offset-5">
+                      <label class="checklabel">
+                        <input type="checkbox" data-callback="graphics.setEnableShadows" />
+                        <i class="material-icons"></i>
+                        <span>Enable Shadows</span>
+                      </label>
+                    </div>
+                  </div>
+
+                  <div class="row">
+                    <div class="col-5">
+                      Shadowmap Size
+                    </div>
+                    <div class="col-7">
+                      <div data-callback="graphics.setShadowmapResolution"></div>
+                    </div>
+                  </div>
+
+                  <div class="row">
+                    <div class="col-5">
+                      Cascades
+                    </div>
+                    <div class="col-7">
+                      <div data-callback="graphics.setShadowmapCascades"></div>
+                    </div>
+                  </div>
+
+                  <div class="row">
+                    <div class="col-5">
+                      Cascade Distribution
+                    </div>
+                    <div class="col-7">
+                      <div data-callback="graphics.setShadowmapSplitDistribution"></div>
+                    </div>
+                  </div>
+
+                  <div class="row">
+                    <div class="col-5">
+                      Bias
+                    </div>
+                    <div class="col-7">
+                      <div data-callback="graphics.setShadowmapBias"></div>
+                    </div>
+                  </div>
+
+                  <div class="row">
+                    <div class="col-5">
+                      Depth Range
+                    </div>
+                    <div class="col-7">
+                      <div data-callback="graphics.setShadowmapRange"></div>
+                    </div>
+                  </div>
+
+                  <div class="row">
+                    <div class="col-5">
+                      Sunspace Extension
+                    </div>
+                    <div class="col-7">
+                      <div data-callback="graphics.setShadowmapExtension"></div>
+                    </div>
+                  </div>
+
+                  <div class="row">
+                    <div class="col-7 offset-5">
+                      <label class="checklabel">
+                        <input type="checkbox" data-callback="graphics.setEnableCascadesDebug" />
+                        <i class="material-icons"></i>
+                        <span>Show Shadow LOD</span>
+                      </label>
+                    </div>
+                    <div class="col-7 offset-5">
+                      <label class="checklabel">
+                        <input type="checkbox" data-callback="graphics.setEnableShadowFreeze" />
+                        <i class="material-icons"></i>
+                        <span>Freeze Shadow LOD</span>
+                      </label>
+                    </div>
+                  </div>
+
+                </div>
+              </div>
+
+              <div class="settings-section">
+                <div class="section-header collapsed" id="headingSettings-Optics"
+                  data-toggle="collapse" data-target="#collapseSettings-Optics"
+                  aria-expanded="false" aria-controls="collapseSettings-Optics" type="button">
+                  <i class="material-icons">camera</i><span>Camera</span><i
+                    class="material-icons caret-icon">keyboard_arrow_left</i>
+                </div>
+                <div class="section-body collapse container-fluid" id="collapseSettings-Optics"
+                  aria-labelledby="headingSettings-Optics" data-parent="#settings-accordion">
+
+                  <div id="enableSensorSizeControl">
+                    <div class="row">
+                      <div class="col-5">
+                        Sensor Diagonal (mm)
+                      </div>
+                      <div class="col-7">
+                        <div data-callback="graphics.setSensorDiagonal">
+                        </div>
+                      </div>
+                    </div>
+
+                    <div class="row">
+                      <div class="col-5">
+                        Focal Length (mm)
+                      </div>
+                      <div class="col-7">
+                        <div data-callback="graphics.setFocalLength">
+                        </div>
+                      </div>
+                    </div>
+
+                    <hr class="mt-2">
+                  </div>
+
                   <div class="row">
                     <div class="col-7 offset-5">
                       <label class="checklabel">
                         <input type="checkbox" data-callback="graphics.setEnableHDR" checked />
                         <i class="material-icons"></i>
-                        <span>Enable HDR Rendering</span>
+                        <span>Enable HDR Mode</span>
                       </label>
                     </div>
                   </div>
@@ -352,6 +501,26 @@
 
                   <div class="row hdr-setting">
                     <div class="col-5">
+                      Tone Mapping Mode
+                    </div>
+                    <div class="col-7">
+                      <label class="radiolabel">
+                        <input name="tonemapping_mode" type="radio"
+                          data-callback="graphics.setToneMappingMode0" />
+                        <span>None</span>
+                      </label>
+                    </div>
+                    <div class="col-7 offset-5">
+                      <label class="radiolabel">
+                        <input name="tonemapping_mode" type="radio"
+                          data-callback="graphics.setToneMappingMode1" checked />
+                        <span>Filmic</span>
+                      </label>
+                    </div>
+                  </div>
+
+                  <div class="row hdr-setting">
+                    <div class="col-5">
                       Average Luminance:
                     </div>
                     <div class="col-7" style="text-align: right">
@@ -371,160 +540,6 @@
                 </div>
               </div>
 
-              <div id="enableSensorSizeControl">
-                <div class="settings-section">
-                  <div class="section-header collapsed" id="headingSettings-Optics"
-                    data-toggle="collapse" data-target="#collapseSettings-Optics"
-                    aria-expanded="false" aria-controls="collapseSettings-Optics" type="button">
-                    <i class="material-icons">camera</i><span>Optics</span><i
-                      class="material-icons caret-icon">keyboard_arrow_left</i>
-                  </div>
-                  <div class="section-body collapse container-fluid" id="collapseSettings-Optics"
-                    aria-labelledby="headingSettings-Optics" data-parent="#settings-accordion">
-
-                    <div class="row">
-                      <div class="col-5">
-                        Sensor Diagonal (mm)
-                      </div>
-                      <div class="col-7">
-                        <div data-callback="graphics.setSensorDiagonal">
-                        </div>
-                      </div>
-                    </div>
-
-                    <div class="row">
-                      <div class="col-5">
-                        Focal Length (mm)
-                      </div>
-                      <div class="col-7">
-                        <div data-callback="graphics.setFocalLength">
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-
-                </div>
-              </div>
-
-              <div class="settings-section">
-                <div class="section-header collapsed" id="headingSettings-LightShadow"
-                  data-toggle="collapse" data-target="#collapseSettings-LightShadow"
-                  aria-expanded="false" aria-controls="collapseSettings-LightShadow" type="button">
-                  <i class="material-icons">brightness_medium</i><span>Light & Shadow</span><i
-                    class="material-icons caret-icon">keyboard_arrow_left</i>
-                </div>
-                <div class="section-body collapse container-fluid" id="collapseSettings-LightShadow"
-                  aria-labelledby="headingSettings-LightShadow" data-parent="#settings-accordion">
-
-                  <div class="row">
-                    <div class="col-7 offset-5">
-                      <label class="checklabel">
-                        <input type="checkbox" data-callback="graphics.setEnableLighting" />
-                        <i class="material-icons"></i>
-                        <span>Enable Lighting</span>
-                      </label>
-                    </div>
-                  </div>
-                  <div class="row">
-                    <div class="col-5">
-                      Quality
-                    </div>
-                    <div class="col-7">
-                      <div data-callback="graphics.setLightingQuality"></div>
-                    </div>
-                  </div>
-                  <div class="row">
-                    <div class="col-5">
-                      Ambient Light
-                    </div>
-                    <div class="col-7">
-                      <div data-callback="graphics.setAmbientLight">
-                      </div>
-                    </div>
-                  </div>
-
-                  <div class="row">
-                    <div class="col-7 offset-5">
-                      <label class="checklabel">
-                        <input type="checkbox" data-callback="graphics.setEnableShadows" />
-                        <i class="material-icons"></i>
-                        <span>Enable Shadows</span>
-                      </label>
-                    </div>
-                  </div>
-
-                  <div class="row">
-                    <div class="col-5">
-                      Shadowmap Size
-                    </div>
-                    <div class="col-7">
-                      <div data-callback="graphics.setShadowmapResolution"></div>
-                    </div>
-                  </div>
-
-                  <div class="row">
-                    <div class="col-5">
-                      Cascades
-                    </div>
-                    <div class="col-7">
-                      <div data-callback="graphics.setShadowmapCascades"></div>
-                    </div>
-                  </div>
-
-                  <div class="row">
-                    <div class="col-5">
-                      Cascade Distribution
-                    </div>
-                    <div class="col-7">
-                      <div data-callback="graphics.setShadowmapSplitDistribution"></div>
-                    </div>
-                  </div>
-
-                  <div class="row">
-                    <div class="col-5">
-                      Bias
-                    </div>
-                    <div class="col-7">
-                      <div data-callback="graphics.setShadowmapBias"></div>
-                    </div>
-                  </div>
-
-                  <div class="row">
-                    <div class="col-5">
-                      Depth Range
-                    </div>
-                    <div class="col-7">
-                      <div data-callback="graphics.setShadowmapRange"></div>
-                    </div>
-                  </div>
-
-                  <div class="row">
-                    <div class="col-5">
-                      Sunspace Extension
-                    </div>
-                    <div class="col-7">
-                      <div data-callback="graphics.setShadowmapExtension"></div>
-                    </div>
-                  </div>
-
-                  <div class="row">
-                    <div class="col-7 offset-5">
-                      <label class="checklabel">
-                        <input type="checkbox" data-callback="graphics.setEnableCascadesDebug" />
-                        <i class="material-icons"></i>
-                        <span>Show Shadow LOD</span>
-                      </label>
-                    </div>
-                    <div class="col-7 offset-5">
-                      <label class="checklabel">
-                        <input type="checkbox" data-callback="graphics.setEnableShadowFreeze" />
-                        <i class="material-icons"></i>
-                        <span>Freeze Shadow LOD</span>
-                      </label>
-                    </div>
-                  </div>
-                </div>
-              </div>
             </div>
           </div>
         </div>

--- a/src/cosmoscout/Application.cpp
+++ b/src/cosmoscout/Application.cpp
@@ -1160,6 +1160,23 @@ void Application::registerGuiCallbacks() {
     }
   });
 
+  // Sets the mode used to compute the tone mapping.
+  mGuiManager->getGui()->registerCallback(
+      "graphics.setToneMappingMode0", "Disables Tone Mapping.", std::function([this]() {
+        mSettings->mGraphics.pToneMappingMode = cs::graphics::ToneMappingNode::ToneMappingMode::eNone;
+      }));
+  mGuiManager->getGui()->registerCallback("graphics.setToneMappingMode1",
+      "Enables Filmic Tone Mapping.", std::function([this]() {
+        mSettings->mGraphics.pToneMappingMode = cs::graphics::ToneMappingNode::ToneMappingMode::eFilmic;
+      }));
+  mSettings->mGraphics.pToneMappingMode.connect([this](cs::graphics::ToneMappingNode::ToneMappingMode glareMode) {
+    if (glareMode == cs::graphics::ToneMappingNode::ToneMappingMode::eNone) {
+      mGuiManager->setRadioChecked("graphics.setToneMappingMode0");
+    } else if (glareMode == cs::graphics::ToneMappingNode::ToneMappingMode::eFilmic) {
+      mGuiManager->setRadioChecked("graphics.setToneMappingMode1");
+    }
+  });
+
   // Update the side bar field showing the average luminance of the scene.
   mGraphicsEngine->pAverageLuminance.connect([this](float value) {
     mGuiManager->getGui()->callJavascript("CosmoScout.sidebar.setAverageSceneLuminance", value);

--- a/src/cosmoscout/Application.cpp
+++ b/src/cosmoscout/Application.cpp
@@ -1163,19 +1163,22 @@ void Application::registerGuiCallbacks() {
   // Sets the mode used to compute the tone mapping.
   mGuiManager->getGui()->registerCallback(
       "graphics.setToneMappingMode0", "Disables Tone Mapping.", std::function([this]() {
-        mSettings->mGraphics.pToneMappingMode = cs::graphics::ToneMappingNode::ToneMappingMode::eNone;
+        mSettings->mGraphics.pToneMappingMode =
+            cs::graphics::ToneMappingNode::ToneMappingMode::eNone;
       }));
-  mGuiManager->getGui()->registerCallback("graphics.setToneMappingMode1",
-      "Enables Filmic Tone Mapping.", std::function([this]() {
-        mSettings->mGraphics.pToneMappingMode = cs::graphics::ToneMappingNode::ToneMappingMode::eFilmic;
+  mGuiManager->getGui()->registerCallback(
+      "graphics.setToneMappingMode1", "Enables Filmic Tone Mapping.", std::function([this]() {
+        mSettings->mGraphics.pToneMappingMode =
+            cs::graphics::ToneMappingNode::ToneMappingMode::eFilmic;
       }));
-  mSettings->mGraphics.pToneMappingMode.connect([this](cs::graphics::ToneMappingNode::ToneMappingMode glareMode) {
-    if (glareMode == cs::graphics::ToneMappingNode::ToneMappingMode::eNone) {
-      mGuiManager->setRadioChecked("graphics.setToneMappingMode0");
-    } else if (glareMode == cs::graphics::ToneMappingNode::ToneMappingMode::eFilmic) {
-      mGuiManager->setRadioChecked("graphics.setToneMappingMode1");
-    }
-  });
+  mSettings->mGraphics.pToneMappingMode.connect(
+      [this](cs::graphics::ToneMappingNode::ToneMappingMode glareMode) {
+        if (glareMode == cs::graphics::ToneMappingNode::ToneMappingMode::eNone) {
+          mGuiManager->setRadioChecked("graphics.setToneMappingMode0");
+        } else if (glareMode == cs::graphics::ToneMappingNode::ToneMappingMode::eFilmic) {
+          mGuiManager->setRadioChecked("graphics.setToneMappingMode1");
+        }
+      });
 
   // Update the side bar field showing the average luminance of the scene.
   mGraphicsEngine->pAverageLuminance.connect([this](float value) {

--- a/src/cosmoscout/Application.cpp
+++ b/src/cosmoscout/Application.cpp
@@ -1172,10 +1172,10 @@ void Application::registerGuiCallbacks() {
             cs::graphics::ToneMappingNode::ToneMappingMode::eFilmic;
       }));
   mSettings->mGraphics.pToneMappingMode.connect(
-      [this](cs::graphics::ToneMappingNode::ToneMappingMode glareMode) {
-        if (glareMode == cs::graphics::ToneMappingNode::ToneMappingMode::eNone) {
+      [this](cs::graphics::ToneMappingNode::ToneMappingMode toneMappingMode) {
+        if (toneMappingMode == cs::graphics::ToneMappingNode::ToneMappingMode::eNone) {
           mGuiManager->setRadioChecked("graphics.setToneMappingMode0");
-        } else if (glareMode == cs::graphics::ToneMappingNode::ToneMappingMode::eFilmic) {
+        } else if (toneMappingMode == cs::graphics::ToneMappingNode::ToneMappingMode::eFilmic) {
           mGuiManager->setRadioChecked("graphics.setToneMappingMode1");
         }
       });

--- a/src/cs-core/GraphicsEngine.cpp
+++ b/src/cs-core/GraphicsEngine.cpp
@@ -109,6 +109,11 @@ GraphicsEngine::GraphicsEngine(std::shared_ptr<core::Settings> settings)
   mSettings->mGraphics.pGlareMode.connectAndTouch(
       [this](graphics::HDRBuffer::GlareMode mode) { mHDRBuffer->setGlareMode(mode); });
 
+  mSettings->mGraphics.pToneMappingMode.connectAndTouch(
+      [this](graphics::ToneMappingNode::ToneMappingMode mode) {
+        mToneMappingNode->setToneMappingMode(mode);
+      });
+
   mSettings->mGraphics.pEnableBicubicGlareFilter.connectAndTouch(
       [this](bool enable) { mToneMappingNode->setEnableBicubicGlareFilter(enable); });
 

--- a/src/cs-core/Settings.cpp
+++ b/src/cs-core/Settings.cpp
@@ -222,6 +222,7 @@ void from_json(nlohmann::json const& j, Settings::Graphics& o) {
   Settings::deserialize(j, "glareIntensity", o.pGlareIntensity);
   Settings::deserialize(j, "glareRadius", o.pGlareQuality);
   Settings::deserialize(j, "glareMode", o.pGlareMode);
+  Settings::deserialize(j, "toneMappingMode", o.pToneMappingMode);
   Settings::deserialize(j, "enableBicubicGlareFiltering", o.pEnableBicubicGlareFilter);
   Settings::deserialize(j, "fixedSunDirection", o.pFixedSunDirection);
 }
@@ -254,6 +255,7 @@ void to_json(nlohmann::json& j, Settings::Graphics const& o) {
   Settings::serialize(j, "glareIntensity", o.pGlareIntensity);
   Settings::serialize(j, "glareRadius", o.pGlareQuality);
   Settings::serialize(j, "glareMode", o.pGlareMode);
+  Settings::serialize(j, "toneMappingMode", o.pToneMappingMode);
   Settings::serialize(j, "enableBicubicGlareFiltering", o.pEnableBicubicGlareFilter);
   Settings::serialize(j, "fixedSunDirection", o.pFixedSunDirection);
 }

--- a/src/cs-core/Settings.hpp
+++ b/src/cs-core/Settings.hpp
@@ -10,6 +10,7 @@
 #include "cs_core_export.hpp"
 
 #include "../cs-graphics/HDRBuffer.hpp"
+#include "../cs-graphics/ToneMappingNode.hpp"
 #include "../cs-utils/DefaultProperty.hpp"
 #include "../cs-utils/utils.hpp"
 
@@ -484,6 +485,10 @@ class CS_CORE_EXPORT Settings {
     /// Specifies how the glare is computed.
     utils::DefaultProperty<graphics::HDRBuffer::GlareMode> pGlareMode{
         graphics::HDRBuffer::GlareMode::eSymmetricGauss};
+
+    /// Specifies how the tone mapping is computed.
+    utils::DefaultProperty<graphics::ToneMappingNode::ToneMappingMode> pToneMappingMode{
+        graphics::ToneMappingNode::ToneMappingMode::eFilmic};
 
     /// This makes illumination calculations assume a fixed sun position in the current SPICE frame.
     /// Using the default value glm::dvec3(0.0) disables this feature.

--- a/src/cs-graphics/ToneMappingNode.hpp
+++ b/src/cs-graphics/ToneMappingNode.hpp
@@ -29,6 +29,8 @@ namespace cs::graphics {
 /// all connected cluster slaves are taken into account.
 class CS_GRAPHICS_EXPORT ToneMappingNode : public IVistaOpenGLDraw, public VistaEventHandler {
  public:
+  enum class ToneMappingMode { eNone = 0, eFilmic = 1 };
+
   /// The node will draw to the backbuffer using the contents from the given HDRBuffer.
   explicit ToneMappingNode(std::shared_ptr<HDRBuffer> hdrBuffer);
 
@@ -79,6 +81,10 @@ class CS_GRAPHICS_EXPORT ToneMappingNode : public IVistaOpenGLDraw, public Vista
   void setEnableBicubicGlareFilter(bool enable);
   bool getEnableBicubicGlareFilter() const;
 
+  /// Sets the tone mapping mode to be used.
+  void            setToneMappingMode(ToneMappingMode mode);
+  ToneMappingMode getToneMappingMode() const;
+
   /// Returns the average and maximum luminance across all connected cluster nodes.
   float getLastAverageLuminance() const;
   float getLastMaximumLuminance() const;
@@ -91,16 +97,17 @@ class CS_GRAPHICS_EXPORT ToneMappingNode : public IVistaOpenGLDraw, public Vista
  private:
   std::shared_ptr<HDRBuffer> mHDRBuffer;
 
-  bool  mShaderDirty              = true;
-  float mExposureCompensation     = 0.F;
-  bool  mEnableAutoExposure       = false;
-  float mExposure                 = 0.F;
-  float mAutoExposure             = 0.F;
-  float mMinAutoExposure          = -15.F;
-  float mMaxAutoExposure          = 15.F;
-  float mExposureAdaptionSpeed    = 1.F;
-  float mGlareIntensity           = 0.F;
-  bool  mEnableBicubicGlareFilter = true;
+  bool            mShaderDirty              = true;
+  float           mExposureCompensation     = 0.F;
+  bool            mEnableAutoExposure       = false;
+  float           mExposure                 = 0.F;
+  float           mAutoExposure             = 0.F;
+  float           mMinAutoExposure          = -15.F;
+  float           mMaxAutoExposure          = 15.F;
+  float           mExposureAdaptionSpeed    = 1.F;
+  float           mGlareIntensity           = 0.F;
+  bool            mEnableBicubicGlareFilter = true;
+  ToneMappingMode mToneMappingMode          = ToneMappingMode::eFilmic;
 
   std::unique_ptr<VistaGLSLShader> mShader;
 


### PR DESCRIPTION
This adds the possibility to support multiple tonemapping modes. For now, Filmic and None are supported, but we could add more in the future.

In addition, this reorganizes the settings section of the sidebar a bit to only use two tabs for the graphics settings. 