### PR TITLE
Capture in meters

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,18 +14,23 @@ SPDX-License-Identifier: CC-BY-4.0
 **Release Date:** TBD
 
 #### New Features
+
 * To allow shared code for plugins, without requiring it to be in the core libraries we introduced a new concept called plugin libraries. They are prefixed `csl` and sit beside the traditional plugins in the `plugins` folder.
 * A new powershell script to create plugin libraries has been added: `tools/New-PluginLibrary.ps1`.
 * **New Plugin Library: `csl-node-editor`.** With this library, plugins can provide an interface to create complex data flow graph. The node editor interface is made available via a web server. Hence the node graph can be modified either within CosmoScout VR or on an external device.
 * **New Plugin: `csp-demo-node-editor`.**  An example on how to use the `csl-node-editor` plugin library for creating data flow graphs within CosmoScout VR.
 
 #### Other Changes
+
 * The branching scheme has been simplified. Instead of `master` and `develop`, there is now only a single `main` branch.
 
 #### Refactoring
+
 * The `tools` were moved from `cs-core` to a new plugin library called `csl-tools`. `csp-measurement-tools` are now making use of this new plugin library.
 
 #### Bug Fixes
+
+* The depth images which can be captured with `csp-web-api` are now in meters again.
 
 ## [v1.6.0](https://github.com/cosmoscout/cosmoscout-vr/releases)
 

--- a/plugins/csp-web-api/gui/example-web-frontend.html
+++ b/plugins/csp-web-api/gui/example-web-frontend.html
@@ -247,7 +247,9 @@ SPDX-License-Identifier: MIT
                   <td>depth</td>
                   <td>false</td>
                   <td>If set to 'true', a 32 bit floating point grayscale range image in meters will
-                    be generated instead of a color image.</td>
+                    be generated instead of a color image. If the output format is set to 'png', the
+                    image will not be in meters but contain the actual depth buffer of CosmoScout
+                    VR.</td>
                 </tr>
               </tbody>
             </table>

--- a/plugins/csp-web-api/src/Plugin.cpp
+++ b/plugins/csp-web-api/src/Plugin.cpp
@@ -421,7 +421,7 @@ void Plugin::update() {
         // Capture the depth component.
         std::vector<float> capture(mCaptureWidth * mCaptureHeight);
         glReadPixels(
-            0, 0, mCaptureWidth, mCaptureHeight, GL_DEPTH_COMPONENT, GL_FLOAT, &capture[0]);
+            0, 0, mCaptureWidth, mCaptureHeight, GL_DEPTH_COMPONENT, GL_FLOAT, capture.data());
 
         if (mCaptureFormat == "tiff") {
 
@@ -429,13 +429,14 @@ void Plugin::update() {
           std::array<GLfloat, 16> glMatP{};
           glGetFloatv(GL_PROJECTION_MATRIX, glMatP.data());
           auto      matInvP = glm::inverse(glm::make_mat4x4(glMatP.data()));
-          glm::vec2 pixel(1.f / mCaptureWidth, 1.f / mCaptureHeight);
+          glm::vec2 pixel(1.F / mCaptureWidth, 1.F / mCaptureHeight);
 
           for (size_t i(0); i < capture.size(); ++i) {
-            auto coords = glm::vec2(i % mCaptureWidth, i / mCaptureWidth) * pixel + 0.5f * pixel;
-            auto pos    = matInvP * glm::vec4(2.f * coords - 1.f, 2.f * capture[i] - 1.f, 1.f);
+            auto coords = glm::vec2(i % mCaptureWidth, i / mCaptureWidth) * pixel + 0.5F * pixel;
+            auto pos    = matInvP * glm::vec4(2.F * coords - 1.F, 2.F * capture[i] - 1.F, 1.F);
 
-            float dist = glm::length(pos.xyz() / pos.w) * mSolarSystem->getObserver().getScale();
+            float dist = static_cast<float>(
+                (glm::length(pos.xyz() / pos.w) * mSolarSystem->getObserver().getScale()));
             capture[i] = std::isinf(dist) ? std::numeric_limits<float>::max() : dist;
           }
 


### PR DESCRIPTION
This fixes a regression which causes the depth images which can be captured with the  `csp-web-api` plugin not to be in meters anymore. This was caused by our changed projection matrix.