### PR TITLE
:wrench: Avoid rerenders of unchanging elements.

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,20 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # Changelog of CosmoScout VR
 
+## [v1.8.0](https://github.com/cosmoscout/cosmoscout-vr/releases)
+
+**Release Date:** TBD
+
+#### New Features
+
+#### Other Changes
+
+#### Refactoring
+
+#### Bug Fixes
+
+* The user interface now avoids rerenders of components that did not change. This lead to the whole UI rerendering most of the time. 
+
 ## [v1.7.0](https://github.com/cosmoscout/cosmoscout-vr/releases)
 
 **Release Date:** 2022-12-13

--- a/resources/gui/js/apis/statusbar.js
+++ b/resources/gui/js/apis/statusbar.js
@@ -275,25 +275,38 @@ class StatusbarApi extends IApi {
    */
   update() {
     let pos = CosmoScout.state.pointerPosition;
+
     if (pos !== undefined) {
-      this._pointerContainer.innerText =
-          `${CosmoScout.utils.formatLongitude(pos[0]) + CosmoScout.utils.formatLatitude(pos[1])}(${
-              CosmoScout.utils.formatHeight(pos[2])})`;
+      const newText =`${CosmoScout.utils.formatLongitude(pos[0]) + CosmoScout.utils.formatLatitude(pos[1])}(${
+          CosmoScout.utils.formatHeight(pos[2])})`;
+      if (this._pointerContainer.innerHTML !== newText) {
+        this._pointerContainer.innerHTML = newText;
+      }
     } else {
-      this._pointerContainer.innerText = ' - ';
+      const newText = ' - ';
+      if (this._pointerContainer.innerHTML !== newText) {
+        this._pointerContainer.innerHTML = newText;
+      }
     }
 
     pos = CosmoScout.state.observerLngLatHeight;
     if (pos !== undefined) {
-      this._userContainer.innerText =
-          `${CosmoScout.utils.formatLongitude(pos[0]) + CosmoScout.utils.formatLatitude(pos[1])}(${
-              CosmoScout.utils.formatHeight(pos[2])})`;
+      const newText =`${CosmoScout.utils.formatLongitude(pos[0]) + CosmoScout.utils.formatLatitude(pos[1])}(${
+          CosmoScout.utils.formatHeight(pos[2])})`;
+      if (this._userContainer.innerHTML !== newText) {
+        this._userContainer.innerHTML = newText;
+      }
     } else {
-      this._userContainer.innerText = ' - ';
+      if (this._userContainer.innerHTML !== ' - ') {
+        this._userContainer.innerHTML = ' - ';
+      }
     }
 
     if (CosmoScout.state.observerSpeed !== undefined) {
-      this._speedContainer.innerText = CosmoScout.utils.formatSpeed(CosmoScout.state.observerSpeed);
+      const newText = CosmoScout.utils.formatSpeed(CosmoScout.state.observerSpeed);
+      if (this._speedContainer.innerHTML !== newText) {
+        this._speedContainer.innerHTML = newText;
+      }
     }
   }
 

--- a/resources/gui/js/apis/statusbar.js
+++ b/resources/gui/js/apis/statusbar.js
@@ -253,7 +253,8 @@ class StatusbarApi extends IApi {
               // completion.
               this._suggestionField.insertAdjacentHTML("beforeend", `<span class='${classNames}'
                        onclick='CosmoScout.statusbar._setCompletion(${prefixBegin}, ${prefixEnd}, 
-                                                              ${finalCursorPos}, "${completion}");'>
+                                                              ${finalCursorPos}, "${
+                                                                        completion}");'>
                        ${element}
                 </span>`);
             });
@@ -277,8 +278,9 @@ class StatusbarApi extends IApi {
     let pos = CosmoScout.state.pointerPosition;
 
     if (pos !== undefined) {
-      const newText =`${CosmoScout.utils.formatLongitude(pos[0]) + CosmoScout.utils.formatLatitude(pos[1])}(${
-          CosmoScout.utils.formatHeight(pos[2])})`;
+      const newText =
+          `${CosmoScout.utils.formatLongitude(pos[0]) + CosmoScout.utils.formatLatitude(pos[1])}(${
+              CosmoScout.utils.formatHeight(pos[2])})`;
       if (this._pointerContainer.innerHTML !== newText) {
         this._pointerContainer.innerHTML = newText;
       }
@@ -291,8 +293,9 @@ class StatusbarApi extends IApi {
 
     pos = CosmoScout.state.observerLngLatHeight;
     if (pos !== undefined) {
-      const newText =`${CosmoScout.utils.formatLongitude(pos[0]) + CosmoScout.utils.formatLatitude(pos[1])}(${
-          CosmoScout.utils.formatHeight(pos[2])})`;
+      const newText =
+          `${CosmoScout.utils.formatLongitude(pos[0]) + CosmoScout.utils.formatLatitude(pos[1])}(${
+              CosmoScout.utils.formatHeight(pos[2])})`;
       if (this._userContainer.innerHTML !== newText) {
         this._userContainer.innerHTML = newText;
       }

--- a/resources/gui/js/apis/statusbar.js
+++ b/resources/gui/js/apis/statusbar.js
@@ -297,8 +297,9 @@ class StatusbarApi extends IApi {
         this._userContainer.innerHTML = newText;
       }
     } else {
-      if (this._userContainer.innerHTML !== ' - ') {
-        this._userContainer.innerHTML = ' - ';
+      const newText = ' - ';
+      if (this._userContainer.innerHTML !== newText) {
+        this._userContainer.innerHTML = newText;
       }
     }
 

--- a/resources/gui/js/apis/statusbar.js
+++ b/resources/gui/js/apis/statusbar.js
@@ -253,8 +253,7 @@ class StatusbarApi extends IApi {
               // completion.
               this._suggestionField.insertAdjacentHTML("beforeend", `<span class='${classNames}'
                        onclick='CosmoScout.statusbar._setCompletion(${prefixBegin}, ${prefixEnd}, 
-                                                              ${finalCursorPos}, "${
-                                                                        completion}");'>
+                                                              ${finalCursorPos}, "${completion}");'>
                        ${element}
                 </span>`);
             });

--- a/resources/gui/js/apis/timeline.js
+++ b/resources/gui/js/apis/timeline.js
@@ -267,7 +267,11 @@ class TimelineApi extends IApi {
       this._updateOverviewLens();
 
       let dateText = this._centerTime.toISOString().replace('T', ' ').slice(0, 19);
-      document.getElementById('date-label').innerText = dateText;
+
+      const dateLabel = document.getElementById('date-label');
+      if (dateLabel.innerText !== dateText) {
+        dateLabel.innerText = dateText;
+      }
     }
   }
 


### PR DESCRIPTION
After some digging around I found out that the whole UI rerenders basically every frame, because the date-time and statusbar elements were rerendered every frame.

I added a simple check to avoid that from happening.