### PR TITLE
Fix terrain lighting

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,7 @@ SPDX-License-Identifier: CC-BY-4.0
 #### New Features
 
 * The `csp-timings` plugin now also shows the number of generated samples and primitives in the user interface.
+* A new "Ambient Occlusion" slider in the user interface can be used to control the amount of slope shading on the terrain.
 
 #### Other Changes
 

--- a/plugins/csp-lod-bodies/shaders/Planet.frag
+++ b/plugins/csp-lod-bodies/shaders/Planet.frag
@@ -14,6 +14,7 @@ uniform float heightMax;
 uniform float slopeMin;
 uniform float slopeMax;
 uniform float ambientBrightness;
+uniform float ambientOcclusion;
 uniform float texGamma;
 uniform vec4  uSunDirIlluminance;
 
@@ -149,9 +150,7 @@ void main() {
   fragColor.rgb = mix(fragColor.rgb * luminance, fragColor.rgb, ambient);
 
   // hill shading / pseudo ambient occlusion
-  const float hillShadingIntensity = 0.99;
-  float hillShading = mix(1.0, max(0, dot(idealNormal, surfaceNormal)), hillShadingIntensity);
-  fragColor.rgb *= hillShading;
+  fragColor.rgb *= mix(1.0, max(0, dot(idealNormal, surfaceNormal)), ambientOcclusion);
 #endif
 
 #if $ENABLE_HDR

--- a/plugins/csp-lod-bodies/shaders/Planet.frag
+++ b/plugins/csp-lod-bodies/shaders/Planet.frag
@@ -127,9 +127,8 @@ void main() {
   luminance *= VP_getShadow(fsIn.position);
 #endif
 
-// To make the amount of ambient brightness perceptually linear in HDR mode we have to reduce small
-// values a lot.
 #if $ENABLE_HDR
+  // Make the amount of ambient brightness perceptually linear in HDR mode.
   float ambient = pow(ambientBrightness, VP_E);
   float f_r = BRDF_HDR(N, L, V);
 #else
@@ -149,11 +148,13 @@ void main() {
   }
   fragColor.rgb = mix(fragColor.rgb * luminance, fragColor.rgb, ambient);
 
-  // hill shading / pseudo ambient occlusion
+  // Add some hill shading (pseudo ambient occlusion).
   fragColor.rgb *= mix(1.0, max(0, dot(idealNormal, surfaceNormal)), ambientOcclusion);
 #endif
 
 #if $ENABLE_HDR
+  // In HDR-mode, we have to add the sun's luminance and divide by the average intensity of the
+  // texture map.
   fragColor.rgb *= uSunDirIlluminance.w / $AVG_LINEAR_IMG_INTENSITY;
 #endif
 
@@ -179,6 +180,7 @@ void main() {
   }
 
 #if $ENABLE_HDR
+  // Make sure that the color overlays are visible in HDR mode.
   debugColor.rgb *= uSunDirIlluminance.w;
 #endif
 

--- a/plugins/csp-lod-bodies/shaders/Planet.frag
+++ b/plugins/csp-lod-bodies/shaders/Planet.frag
@@ -162,10 +162,11 @@ void main() {
   // color area by level
   const float minLevel   = 1;
   const float maxLevel   = 15;
-  const float brightness = 0.5;
+  const float brightness = 0.3;
+  const float alpha      = 0.5;
 
   float level      = clamp(log2(float(VP_offsetScale.z)), minLevel, maxLevel);
-  vec4  debugColor = vec4(heat((level - minLevel) / (maxLevel - minLevel)), 0.5);
+  vec4  debugColor = vec4(heat((level - minLevel) / (maxLevel - minLevel)), alpha);
   debugColor.rgb   = mix(debugColor.rgb, vec3(1), brightness);
 
   // Create a red border around each tile. As the outer-most vertex is the bottom of the skirt, we
@@ -176,12 +177,13 @@ void main() {
   if (fsIn.vertexPosition.x < edgeWidth || fsIn.vertexPosition.y < edgeWidth ||
       fsIn.vertexPosition.x > maxVertex - edgeWidth || 
       fsIn.vertexPosition.y > maxVertex - edgeWidth) {
-    debugColor = vec4(1.0, 0.0, 0.0, 0.5);
+    debugColor = vec4(1.0, 0.0, 0.0, alpha);
   }
 
 #if $ENABLE_HDR
   // Make sure that the color overlays are visible in HDR mode.
-  debugColor.rgb *= uSunDirIlluminance.w;
+  debugColor.rgb = SRGBtoLINEAR(debugColor.rgb);
+  debugColor.rgb *= uSunDirIlluminance.w / VP_PI / $AVG_LINEAR_IMG_INTENSITY;
 #endif
 
   fragColor.rgb = mix(fragColor.rgb, debugColor.rgb, debugColor.a);

--- a/plugins/csp-lod-bodies/shaders/Planet.frag
+++ b/plugins/csp-lod-bodies/shaders/Planet.frag
@@ -188,6 +188,10 @@ void main() {
     debugColor = vec4(1.0, 0.0, 0.0, 0.5);
   }
 
+#if $ENABLE_HDR
+  debugColor.rgb *= uSunDirIlluminance.w;
+#endif
+
   fragColor.rgb = mix(fragColor.rgb, debugColor.rgb, debugColor.a);
 #endif
 

--- a/plugins/csp-lod-bodies/shaders/VistaPlanetTerrainShaderUniforms.glsl
+++ b/plugins/csp-lod-bodies/shaders/VistaPlanetTerrainShaderUniforms.glsl
@@ -6,7 +6,8 @@
 // SPDX-License-Identifier: MIT
 
 // constants -------------------------------------------------------------------
-const float VP_PI = 3.1415926535897932384626433832795;
+const float VP_PI = 3.141592653;
+const float VP_E  = 2.718281828;
 
 // uniforms - global for a planet ----------------------------------------------
 uniform mat4  VP_matProjection;

--- a/plugins/csp-lod-bodies/src/PlanetShader.cpp
+++ b/plugins/csp-lod-bodies/src/PlanetShader.cpp
@@ -231,6 +231,9 @@ void PlanetShader::bind() {
   loc = mShader.GetUniformLocation("ambientBrightness");
   mShader.SetUniform(loc, mSettings->mGraphics.pAmbientBrightness.get());
 
+  loc = mShader.GetUniformLocation("ambientOcclusion");
+  mShader.SetUniform(loc, mSettings->mGraphics.pAmbientOcclusion.get());
+
   loc = mShader.GetUniformLocation("texGamma");
   mShader.SetUniform(loc, mPluginSettings->mTextureGamma.get());
 

--- a/plugins/csp-lod-bodies/src/TileRenderer.cpp
+++ b/plugins/csp-lod-bodies/src/TileRenderer.cpp
@@ -178,11 +178,13 @@ void TileRenderer::preRenderTiles(cs::graphics::ShadowMap* shadowMap) {
   // bind textures with tile data
   if (glDEM) {
     glActiveTexture(texUnitNameDEM);
+    glBindTexture(GL_TEXTURE_2D, 0);
     glBindTexture(GL_TEXTURE_2D_ARRAY, glDEM->getTextureId());
   }
 
   if (glIMG) {
     glActiveTexture(texUnitNameIMG);
+    glBindTexture(GL_TEXTURE_2D, 0);
     glBindTexture(GL_TEXTURE_2D_ARRAY, glIMG->getTextureId());
   }
 

--- a/plugins/csp-simple-bodies/src/SimpleBody.cpp
+++ b/plugins/csp-simple-bodies/src/SimpleBody.cpp
@@ -101,7 +101,8 @@ in vec3 vSunDirection;
 // outputs
 layout(location = 0) out vec3 oColor;
 
-const float PI = 3.141592653589793;
+const float PI = 3.141592654;
+const float E  = 2.718281828;
 
 vec3 SRGBtoLINEAR(vec3 srgbIn)
 {
@@ -157,14 +158,17 @@ void main()
     oColor = texture(uSurfaceTexture, vTexCoords).rgb;
 
     #ifdef ENABLE_HDR
+      // Make the amount of ambient brightness perceptually linear in HDR mode.
+      float ambient = pow(uAmbientBrightness, E);
       oColor = SRGBtoLINEAR(oColor) * uSunIlluminance / PI;
     #else
+      float ambient = uAmbientBrightness;
       oColor = oColor * uSunIlluminance;
     #endif
 
     #ifdef ENABLE_LIGHTING
-      float light = orenNayar(normalize(vNormal), normalize(vSunDirection), -normalize(vPosition));
-      oColor = mix(oColor * uAmbientBrightness, oColor * getEclipseShadow(vPosition), light);
+      vec3 light = getEclipseShadow(vPosition) * orenNayar(normalize(vNormal), normalize(vSunDirection), -normalize(vPosition));
+      oColor = mix(oColor * light, oColor, ambient);
     #endif
 }
 )";

--- a/resources/gui/cosmoscout.html
+++ b/resources/gui/cosmoscout.html
@@ -267,6 +267,15 @@ SPDX-License-Identifier: MIT
                       </div>
                     </div>
                   </div>
+                  <div class="row">
+                    <div class="col-5">
+                      Ambient Occlusion
+                    </div>
+                    <div class="col-7">
+                      <div data-callback="graphics.setAmbientOcclusion">
+                      </div>
+                    </div>
+                  </div>
 
                   <hr class="mt-2">
 
@@ -913,6 +922,7 @@ SPDX-License-Identifier: MIT
       CosmoScout.gui.initSlider("graphics.setExposureCompensation", -10, 10, 0.5, [0]);
       CosmoScout.gui.initSlider("graphics.setExposureAdaptionSpeed", 0, 20, 0.1, [3]);
       CosmoScout.gui.initSlider("graphics.setAmbientLight", 0.0, 1.0, 0.001, [0.0]);
+      CosmoScout.gui.initSlider("graphics.setAmbientOcclusion", 0.0, 1.0, 0.001, [0.5]);
       CosmoScout.gui.initSlider("graphics.setExposureRange", -30.0, 30, 0.1, [-14, 9]);
       CosmoScout.gui.initSlider("graphics.setGlareIntensity", 0.0, 1, 0.01, [0.1]);
       CosmoScout.gui.initSlider("graphics.setGlareQuality", 0, 5, 1, [0]);

--- a/resources/gui/cosmoscout.html
+++ b/resources/gui/cosmoscout.html
@@ -912,7 +912,7 @@ SPDX-License-Identifier: MIT
       CosmoScout.gui.initSlider("graphics.setFocalLength", 5.0, 500, 1, [24]);
       CosmoScout.gui.initSlider("graphics.setExposureCompensation", -10, 10, 0.5, [0]);
       CosmoScout.gui.initSlider("graphics.setExposureAdaptionSpeed", 0, 20, 0.1, [3]);
-      CosmoScout.gui.initSlider("graphics.setAmbientLight", 0.0, 1.0, 0.001, [0.25]);
+      CosmoScout.gui.initSlider("graphics.setAmbientLight", 0.0, 1.0, 0.001, [0.0]);
       CosmoScout.gui.initSlider("graphics.setExposureRange", -30.0, 30, 0.1, [-14, 9]);
       CosmoScout.gui.initSlider("graphics.setGlareIntensity", 0.0, 1, 0.01, [0.1]);
       CosmoScout.gui.initSlider("graphics.setGlareQuality", 0, 5, 1, [0]);

--- a/src/cosmoscout/Application.cpp
+++ b/src/cosmoscout/Application.cpp
@@ -1252,15 +1252,17 @@ void Application::registerGuiCallbacks() {
 
   // Adjusts the amount of ambient lighting.
   mGuiManager->getGui()->registerCallback("graphics.setAmbientLight",
-      "Sets the amount of ambient light.",
-      std::function([this](double val) { mSettings->mGraphics.pAmbientBrightness = val; }));
+      "Sets the amount of ambient light.", std::function([this](double val) {
+        mSettings->mGraphics.pAmbientBrightness = static_cast<float>(val);
+      }));
   mSettings->mGraphics.pAmbientBrightness.connect(
       [this](float val) { mGuiManager->setSliderValue("graphics.setAmbientLight", val); });
 
   // Adjusts the amount of ambient occlusion.
   mGuiManager->getGui()->registerCallback("graphics.setAmbientOcclusion",
-      "Sets the amount of ambient occlusion.",
-      std::function([this](double val) { mSettings->mGraphics.pAmbientOcclusion = val; }));
+      "Sets the amount of ambient occlusion.", std::function([this](double val) {
+        mSettings->mGraphics.pAmbientOcclusion = static_cast<float>(val);
+      }));
   mSettings->mGraphics.pAmbientOcclusion.connect(
       [this](float val) { mGuiManager->setSliderValue("graphics.setAmbientOcclusion", val); });
 

--- a/src/cosmoscout/Application.cpp
+++ b/src/cosmoscout/Application.cpp
@@ -1252,12 +1252,10 @@ void Application::registerGuiCallbacks() {
 
   // Adjusts the amount of ambient lighting.
   mGuiManager->getGui()->registerCallback("graphics.setAmbientLight",
-      "Sets the amount of ambient light.", std::function([this](double val) {
-        mSettings->mGraphics.pAmbientBrightness = static_cast<float>(std::pow(val, 10.0));
-      }));
-  mSettings->mGraphics.pAmbientBrightness.connect([this](float val) {
-    mGuiManager->setSliderValue("graphics.setAmbientLight", std::pow(val, 0.1F));
-  });
+      "Sets the amount of ambient light.",
+      std::function([this](double val) { mSettings->mGraphics.pAmbientBrightness = val; }));
+  mSettings->mGraphics.pAmbientBrightness.connect(
+      [this](float val) { mGuiManager->setSliderValue("graphics.setAmbientLight", val); });
 
   // Adjusts the exposure range for auto exposure.
   mGuiManager->getGui()->registerCallback("graphics.setExposureRange",

--- a/src/cosmoscout/Application.cpp
+++ b/src/cosmoscout/Application.cpp
@@ -1257,6 +1257,13 @@ void Application::registerGuiCallbacks() {
   mSettings->mGraphics.pAmbientBrightness.connect(
       [this](float val) { mGuiManager->setSliderValue("graphics.setAmbientLight", val); });
 
+  // Adjusts the amount of ambient occlusion.
+  mGuiManager->getGui()->registerCallback("graphics.setAmbientOcclusion",
+      "Sets the amount of ambient occlusion.",
+      std::function([this](double val) { mSettings->mGraphics.pAmbientOcclusion = val; }));
+  mSettings->mGraphics.pAmbientOcclusion.connect(
+      [this](float val) { mGuiManager->setSliderValue("graphics.setAmbientOcclusion", val); });
+
   // Adjusts the exposure range for auto exposure.
   mGuiManager->getGui()->registerCallback("graphics.setExposureRange",
       "Sets the minimum and maximum value in [EV] for auto-exposure.",
@@ -1686,6 +1693,7 @@ void Application::unregisterGuiCallbacks() {
   mGuiManager->getGui()->unregisterCallback("core.reloadPlugin");
   mGuiManager->getGui()->unregisterCallback("core.unloadPlugin");
   mGuiManager->getGui()->unregisterCallback("graphics.setAmbientLight");
+  mGuiManager->getGui()->unregisterCallback("graphics.setAmbientOcclusion");
   mGuiManager->getGui()->unregisterCallback("graphics.setEnableCascadesDebug");
   mGuiManager->getGui()->unregisterCallback("graphics.setEnableLighting");
   mGuiManager->getGui()->unregisterCallback("graphics.setEnableShadowFreeze");

--- a/src/cs-core/Settings.cpp
+++ b/src/cs-core/Settings.cpp
@@ -298,6 +298,7 @@ void from_json(nlohmann::json const& j, Settings::Graphics& o) {
   Settings::deserialize(j, "sensorDiagonal", o.pSensorDiagonal);
   Settings::deserialize(j, "focalLength", o.pFocalLength);
   Settings::deserialize(j, "ambientBrightness", o.pAmbientBrightness);
+  Settings::deserialize(j, "ambientOcclusion", o.pAmbientOcclusion);
   Settings::deserialize(j, "glareIntensity", o.pGlareIntensity);
   Settings::deserialize(j, "glareRadius", o.pGlareQuality);
   Settings::deserialize(j, "glareMode", o.pGlareMode);
@@ -333,6 +334,7 @@ void to_json(nlohmann::json& j, Settings::Graphics const& o) {
   Settings::serialize(j, "sensorDiagonal", o.pSensorDiagonal);
   Settings::serialize(j, "focalLength", o.pFocalLength);
   Settings::serialize(j, "ambientBrightness", o.pAmbientBrightness);
+  Settings::serialize(j, "ambientOcclusion", o.pAmbientOcclusion);
   Settings::serialize(j, "glareIntensity", o.pGlareIntensity);
   Settings::serialize(j, "glareRadius", o.pGlareQuality);
   Settings::serialize(j, "glareMode", o.pGlareMode);

--- a/src/cs-core/Settings.hpp
+++ b/src/cs-core/Settings.hpp
@@ -436,7 +436,7 @@ class CS_CORE_EXPORT Settings {
     utils::DefaultProperty<float> pFocalLength{24.F};
 
     /// The amount of ambient light. This should be in the range 0-1.
-    utils::DefaultProperty<float> pAmbientBrightness{std::pow(0.25F, 10.F)};
+    utils::DefaultProperty<float> pAmbientBrightness{0.F};
 
     /// The amount of artifical glare. Has no effect if HDR rendering is disabled. This should be in
     /// the range 0-1. A value of zero disables the glare.

--- a/src/cs-core/Settings.hpp
+++ b/src/cs-core/Settings.hpp
@@ -438,6 +438,9 @@ class CS_CORE_EXPORT Settings {
     /// The amount of ambient light. This should be in the range 0-1.
     utils::DefaultProperty<float> pAmbientBrightness{0.F};
 
+    /// The amount of ambient occlusion. This should be in the range 0-1.
+    utils::DefaultProperty<float> pAmbientOcclusion{0.5F};
+
     /// The amount of artifical glare. Has no effect if HDR rendering is disabled. This should be in
     /// the range 0-1. A value of zero disables the glare.
     utils::DefaultProperty<float> pGlareIntensity{0.1F};


### PR DESCRIPTION
Changes:
* Added a new `ambientOcclusion` setting which for now controls the amount of artificial hill-shading on the terrain. Previously, this was hard-coded.
* Reduced some code duplication in the planet shader.
* The tile-borders of `csp-lod-bodies` can now also be visualized in HDR mode.
* Ambient lighting works again in HDR-mode,
* Ambient lighting is set to a more realistic value of zero per default.
* The mapping of the ambient-lighting slider now feels more linear (both in HDR and non-HDR mode).
* If ambient lighting is set to one, the terrain is not affect by the sun light direction anymore.
* The ambient lighting now properly interacts with eclipse shadows on simple bodies.