### PR TITLE
Increase maximum HEALPix depth

### DIFF
--- a/config/base/scene/simple_desktop.json
+++ b/config/base/scene/simple_desktop.json
@@ -19,12 +19,12 @@
     ]
   },
   "sceneScale": {
-    "minScale": 5,
-    "maxScale": 100000000000000000,
-    "closeVisualDistance": 5,
-    "farVisualDistance": 5,
-    "closeRealDistance": 1.7,
-    "farRealDistance": 1000000,
+    "minScale": 1.0,
+    "maxScale": 1e17,
+    "closeVisualDistance": 5.0,
+    "farVisualDistance": 5.0,
+    "closeRealDistance": 1.0,
+    "farRealDistance": 1.0,
     "lockWeight": 0.1,
     "trackWeight": 0.0002,
     "minObjectSize": 10000.0

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,10 +18,6 @@ SPDX-License-Identifier: CC-BY-4.0
 * The `csp-timings` plugin now also shows the number of generated samples and primitives in the user interface.
 * A new "Ambient Occlusion" slider in the user interface can be used to control the amount of slope shading on the terrain.
 
-#### Other Changes
-
-* In order to improve the rendering performance, the stars of `csp-stars` are not drawn anymore if the observer is on the day-side of a planet with an atmosphere.
-
 #### Refactoring
 
 * The `csp-lod-bodies` plugin has received some major refactoring. Here are the main changes:
@@ -41,6 +37,11 @@ SPDX-License-Identifier: CC-BY-4.0
 
 #### Other Changes
 
+* A couple of changes and fixes were added in order to support much higher resolution map data:
+  * Increased maximum HEALPix depth from 20 to 30. This reduces our minimum tile size from about 13 m to 13 mm.
+  * Improved the scene scaling of the default configuration to allow for a smoother navigation close to the surface.
+  * Fixed an issue which led to an accumulated error in the rotation quaternion of the observer.
+  * Fixed an issue which caused precision issues for very small movements of the click-and-drag navigation.
 * In order to improve the rendering performance, the stars of `csp-stars` are not drawn anymore if the observer is on the day-side of a planet with an atmosphere.
 * The default exposure and glare values as well as the glare-slider mapping have been tweaked for a better appearance of the atmospheres in HDR mode.
 * The default star rendering mode has been changed to `eSmoothDisc`

--- a/plugins/csp-lod-bodies/src/HEALPix.cpp
+++ b/plugins/csp-lod-bodies/src/HEALPix.cpp
@@ -339,11 +339,13 @@ glm::dvec2 HEALPixLevel::bxy2geo(glm::i64vec3 const& bxy) const {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-/* static */ std::array<HEALPixLevel, 20> const HEALPix::sLevels = {
+/* static */ std::array<HEALPixLevel, 30> const HEALPix::sLevels = {
     {HEALPixLevel(0), HEALPixLevel(1), HEALPixLevel(2), HEALPixLevel(3), HEALPixLevel(4),
         HEALPixLevel(5), HEALPixLevel(6), HEALPixLevel(7), HEALPixLevel(8), HEALPixLevel(9),
         HEALPixLevel(10), HEALPixLevel(11), HEALPixLevel(12), HEALPixLevel(13), HEALPixLevel(14),
-        HEALPixLevel(15), HEALPixLevel(16), HEALPixLevel(17), HEALPixLevel(18), HEALPixLevel(19)}};
+        HEALPixLevel(15), HEALPixLevel(16), HEALPixLevel(17), HEALPixLevel(18), HEALPixLevel(19),
+        HEALPixLevel(20), HEALPixLevel(21), HEALPixLevel(22), HEALPixLevel(23), HEALPixLevel(24),
+        HEALPixLevel(25), HEALPixLevel(26), HEALPixLevel(27), HEALPixLevel(28), HEALPixLevel(29)}};
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/plugins/csp-lod-bodies/src/HEALPix.hpp
+++ b/plugins/csp-lod-bodies/src/HEALPix.hpp
@@ -198,6 +198,13 @@ class HEALPix {
   static TileId getParentTileId(TileId const& childId);
 
  private:
+  // The maximum depth of the HEALPix tree limits the resolution we can display data at. For Earth,
+  // the base patches have a edge length of about 7000 km. If, for example, each tile has a
+  // resolution of 256 data points, the maximum resolution at level i would be:
+  //
+  // r = 7000.000 m / 2^i / 256.
+  //
+  // 30 levels give us a minimum data point separation of 0.05 mm :)
   static std::array<HEALPixLevel, 30> const sLevels;
 };
 } // namespace csp::lodbodies

--- a/plugins/csp-lod-bodies/src/HEALPix.hpp
+++ b/plugins/csp-lod-bodies/src/HEALPix.hpp
@@ -198,7 +198,7 @@ class HEALPix {
   static TileId getParentTileId(TileId const& childId);
 
  private:
-  static std::array<HEALPixLevel, 20> const sLevels;
+  static std::array<HEALPixLevel, 30> const sLevels;
 };
 } // namespace csp::lodbodies
 

--- a/plugins/csp-lod-bodies/src/HEALPix.hpp
+++ b/plugins/csp-lod-bodies/src/HEALPix.hpp
@@ -199,12 +199,13 @@ class HEALPix {
 
  private:
   // The maximum depth of the HEALPix tree limits the resolution we can display data at. For Earth,
-  // the base patches have a edge length of about 7000 km. If, for example, each tile has a
-  // resolution of 256 data points, the maximum resolution at level i would be:
+  // the base patches have a edge length of about 7000 km. Hence the edge length at level i is about
   //
-  // r = 7000.000 m / 2^i / 256.
+  // r = 7000 km / 2^i
   //
-  // 30 levels give us a minimum data point separation of 0.05 mm :)
+  // The HEALPix code seems to be limited to 30 levels. This results in a minimum tile size of about
+  // 13 mm. If, for example, each tile has a resolution of 256 data points, the minimum spacing of
+  // adjacent vertices would be about 0.05 mm.
   static std::array<HEALPixLevel, 30> const sLevels;
 };
 } // namespace csp::lodbodies

--- a/plugins/csp-lod-bodies/src/utils.cpp
+++ b/plugins/csp-lod-bodies/src/utils.cpp
@@ -276,8 +276,8 @@ bool intersectPlanet(
       // Tile sizes
       int size = tile->getResolution();
 
-      auto max_tile_samplings = sqrt((size * size) + (size * size));
-      auto max_bbox_samplings = sqrt(
+      auto max_tile_samplings = std::sqrt((size * size) + (size * size));
+      auto max_bbox_samplings = std::sqrt(
           (max_tile_samplings * max_tile_samplings) + (max_tile_samplings * max_tile_samplings));
 
       auto step_factor =

--- a/src/cosmoscout/ObserverNavigationNode.cpp
+++ b/src/cosmoscout/ObserverNavigationNode.cpp
@@ -156,7 +156,7 @@ bool ObserverNavigationNode::DoEvalNode() {
       glm::angle(qRotation) * dDeltaTime * mMaxAngularSpeed * mAngularSpeed.get(dTtime);
 
   if (dRotationAngle != 0.0) {
-    oObs.setRotation(oObs.getRotation() * glm::angleAxis(dRotationAngle, vRotationAxis));
+    oObs.setRotation(glm::normalize(oObs.getRotation() * glm::angleAxis(dRotationAngle, vRotationAxis)));
   }
 
   return true;

--- a/src/cosmoscout/ObserverNavigationNode.cpp
+++ b/src/cosmoscout/ObserverNavigationNode.cpp
@@ -156,7 +156,8 @@ bool ObserverNavigationNode::DoEvalNode() {
       glm::angle(qRotation) * dDeltaTime * mMaxAngularSpeed * mAngularSpeed.get(dTtime);
 
   if (dRotationAngle != 0.0) {
-    oObs.setRotation(glm::normalize(oObs.getRotation() * glm::angleAxis(dRotationAngle, vRotationAxis)));
+    oObs.setRotation(
+        glm::normalize(oObs.getRotation() * glm::angleAxis(dRotationAngle, vRotationAxis)));
   }
 
   return true;

--- a/src/cs-core/DragNavigation.cpp
+++ b/src/cs-core/DragNavigation.cpp
@@ -137,14 +137,14 @@ void DragNavigation::update() {
   double const smoothThreshold = 0.8;
 
   if (mInputManager->pButtons[0].get() || mInputManager->pButtons[1].get()) {
-    glm::dvec3 end_vec;
-    glm::dvec3 start_vec;
+    glm::dvec3 endVec;
+    glm::dvec3 startVec;
     bool       bPerformRotation = false;
     mLocalRotation              = mInputManager->pButtons[1].get();
 
     if (mLocalRotation) {
-      start_vec        = mStartRayDir;
-      end_vec          = rayDir;
+      startVec         = mStartRayDir;
+      endVec           = rayDir;
       bPerformRotation = true;
     } else if (mDraggingPlanet) {
       // The radius is used to rotate the camera around the target body on a sphere of this exact
@@ -158,13 +158,13 @@ void DragNavigation::update() {
 
       // we do not want to drag something behind us
       if (t && t.value() > 0.0) {
-        end_vec          = glm::normalize((rayOrigin + (t.value() * rayDir)));
-        start_vec        = glm::normalize(mStartIntersection);
+        endVec           = glm::normalize((rayOrigin + (t.value() * rayDir)));
+        startVec         = glm::normalize(mStartIntersection);
         bPerformRotation = true;
       }
     } else {
-      start_vec        = rayDir;
-      end_vec          = mStartRayDir;
+      startVec         = rayDir;
+      endVec           = mStartRayDir;
       bPerformRotation = true;
     }
 
@@ -172,7 +172,7 @@ void DragNavigation::update() {
     if (bPerformRotation && !mInputManager->pActiveNode.get() &&
         !mInputManager->pActiveGuiItem.get()) {
       // Rotation angle computations:
-      glm::dvec3 currentAxis = glm::cross(start_vec, end_vec);
+      glm::dvec3 currentAxis = glm::cross(startVec, endVec);
 
       // Only if the vectors are not co-linear
       if (glm::length(currentAxis) > 0) {
@@ -180,7 +180,7 @@ void DragNavigation::update() {
         mCurrentAxis = glm::normalize(currentAxis);
 
         // The final amount of camera rotation around the body center
-        double targetAngle = -2.0 * std::asin(0.5 * glm::length(start_vec - end_vec));
+        double targetAngle = -2.0 * std::asin(0.5 * glm::length(startVec - endVec));
 
         // reduce rotation speed close to planet
         if (!mDraggingPlanet && !mLocalRotation && mSolarSystem->pActiveObject.get()) {

--- a/src/cs-core/DragNavigation.cpp
+++ b/src/cs-core/DragNavigation.cpp
@@ -179,7 +179,7 @@ void DragNavigation::update() {
         // The rotation axis is perpendicular to the start and the end position vectors
         mCurrentAxis = glm::normalize(currentAxis);
 
-        // The final amount of camera rotation around planet center
+        // The final amount of camera rotation around the body center
         double targetAngle = -2.0 * std::asin(0.5 * glm::length(start_vec - end_vec));
 
         // reduce rotation speed close to planet

--- a/src/cs-core/DragNavigation.hpp
+++ b/src/cs-core/DragNavigation.hpp
@@ -61,7 +61,7 @@ class CS_CORE_EXPORT DragNavigation {
   bool       mDoRollCorrection            = false;
   bool       mDoKineticSmoothOut          = false;
   double     mTargetAngle                 = 0.0;
-  float      mCurrentAngleDiff            = 0.F;
+  double     mCurrentAngleDiff            = 0.0;
   glm::dvec3 mCurrentAxis                 = glm::dvec3(1.0, 0.0, 0.0);
 
   glm::dvec3 mStartIntersection = glm::dvec3(0.0);


### PR DESCRIPTION
With this, we can load much more high-resolution data. Changes:

* Increased maximum HEALPix depth from 20 to 30. This reduces our minimum tile size from about 13 m to 13 mm.
* Improved the scene scaling of the default configuration to allow for a smoother navigation close to the surface.
* Fixed an issue which led to an accumulated error in the rotation quaternion of the observer.
* Fixed an issue which caused precision issues for very small movements of the click-and-drag navigation.

With this set of changes, we can go well beyond a 1:1 scene scale and actually explore map data "like an ant" in the sub-millimeter range.