### PR TITLE
Shader issue resolved

### DIFF
--- a/plugins/csp-atmospheres/shaders/csp-atmospheres/atmosphere.frag
+++ b/plugins/csp-atmospheres/shaders/csp-atmospheres/atmosphere.frag
@@ -5,7 +5,7 @@
 // SPDX-FileCopyrightText: German Aerospace Center (DLR) <cosmoscout@dlr.de>
 // SPDX-License-Identifier: MIT
 
-#version 330
+#version 430
 
 // inputs
 in VaryingStruct {

--- a/plugins/csp-atmospheres/shaders/csp-atmospheres/atmosphere.vert
+++ b/plugins/csp-atmospheres/shaders/csp-atmospheres/atmosphere.vert
@@ -5,7 +5,7 @@
 // SPDX-FileCopyrightText: German Aerospace Center (DLR) <cosmoscout@dlr.de>
 // SPDX-License-Identifier: MIT
 
-#version 330
+#version 430
 
 // uniforms
 uniform mat4 uMatInvMV;

--- a/plugins/csp-simple-bodies/src/SimpleBody.cpp
+++ b/plugins/csp-simple-bodies/src/SimpleBody.cpp
@@ -341,7 +341,7 @@ bool SimpleBody::Do() {
     mShader = VistaGLSLShader();
 
     // (Re-)create sphere shader.
-    std::string defines = "#version 330\n";
+    std::string defines = "#version 430\n";
 
     if (mSettings->mGraphics.pEnableHDR.get()) {
       defines += "#define ENABLE_HDR\n";


### PR DESCRIPTION
When you use the `version 330` of atmospheres and simple-bodies shaders, you get the following errors:
```bash
GL_INVALID_OPERATION in glUniform(program not linked)
GL_INVALID_OPERATION in glUniformMatrix(program not linked)
**WARNING** Shader porgram with id 389 is not ready for use. Bind has no effect.
###ERROR### OpenGL  error 1282 (invalid operation)
```
The error was resolved by incrementing the versions of the atmospheres and simple-bodies shaders to `version 430`.