### PR TITLE
Simple Bodies Ring Shadows

### DIFF
--- a/config/base/scene/simple_desktop.json
+++ b/config/base/scene/simple_desktop.json
@@ -826,7 +826,12 @@
           "texture": "../share/resources/textures/callisto.jpg"
         },
         "Saturn": {
-          "texture": "../share/resources/textures/saturn.jpg"
+          "texture": "../share/resources/textures/saturn.jpg",
+          "ring": {
+            "texture": "../share/resources/textures/saturn-rings.png",
+            "innerRadius": 67000000,
+            "outerRadius": 140210000
+          }
         },
         "Mimas": {
           "texture": "../share/resources/textures/mimas.jpg",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,6 +19,7 @@ SPDX-License-Identifier: CC-BY-4.0
 * The `csp-timings` plugin now shows the timings in the world-space gui-area per default. The old behavior can be restored with `"useLocalGui": true` in the plugin's settings.
 * A new "Ambient Occlusion" slider in the user interface can be used to control the amount of slope shading on the terrain.
 * The water surface shader of `csp-atmospheres` has been improved significantly. It now reflects the sky and features some beautiful waves. The waves can be disabled as they are quite demanding in terms of GPU power. Both, the reflections and the waves are not physically based in any way; they are mostly intended for presentation purposes.
+* Bodies in `csp-simple-bodies` can now be shaded by a ring. 
 
 #### Refactoring
 

--- a/plugins/csp-simple-bodies/src/Plugin.cpp
+++ b/plugins/csp-simple-bodies/src/Plugin.cpp
@@ -33,14 +33,30 @@ namespace csp::simplebodies {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
+void from_json(nlohmann::json const& j, Plugin::Settings::SimpleBody::Ring& o) {
+  cs::core::Settings::deserialize(j, "texture", o.mTexture);
+  cs::core::Settings::deserialize(j, "innerRadius", o.mInnerRadius);
+  cs::core::Settings::deserialize(j, "outerRadius", o.mOuterRadius);
+}
+
+void to_json(nlohmann::json& j, Plugin::Settings::SimpleBody::Ring const& o) {
+  cs::core::Settings::serialize(j, "texture", o.mTexture);
+  cs::core::Settings::serialize(j, "innerRadius", o.mInnerRadius);
+  cs::core::Settings::serialize(j, "outerRadius", o.mOuterRadius);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
 void from_json(nlohmann::json const& j, Plugin::Settings::SimpleBody& o) {
   cs::core::Settings::deserialize(j, "texture", o.mTexture);
   cs::core::Settings::deserialize(j, "primeMeridianInCenter", o.mPrimeMeridianInCenter);
+  cs::core::Settings::deserialize(j, "ring", o.mRing);
 }
 
 void to_json(nlohmann::json& j, Plugin::Settings::SimpleBody const& o) {
   cs::core::Settings::serialize(j, "texture", o.mTexture);
   cs::core::Settings::serialize(j, "primeMeridianInCenter", o.mPrimeMeridianInCenter);
+  cs::core::Settings::serialize(j, "ring", o.mRing);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/plugins/csp-simple-bodies/src/Plugin.hpp
+++ b/plugins/csp-simple-bodies/src/Plugin.hpp
@@ -33,10 +33,10 @@ class Plugin : public cs::core::PluginBase {
         /// The path to the texture. The texture should represent a cross section of the ring.
         std::string mTexture;
 
-        /// The distance from the planets center to where the rings start in meter.
+        /// The distance from the planet's center to where the ring starts in meters.
         double mInnerRadius{};
 
-        /// The distance from the planets center to where the rings end in meter.
+        /// The distance from the planet's center to where the ring ends in meters.
         double mOuterRadius{};
       };
 

--- a/plugins/csp-simple-bodies/src/Plugin.hpp
+++ b/plugins/csp-simple-bodies/src/Plugin.hpp
@@ -12,8 +12,8 @@
 #include "../../../src/cs-utils/DefaultProperty.hpp"
 
 #include <map>
-#include <string>
 #include <optional>
+#include <string>
 
 namespace csp::simplebodies {
 

--- a/plugins/csp-simple-bodies/src/Plugin.hpp
+++ b/plugins/csp-simple-bodies/src/Plugin.hpp
@@ -34,10 +34,10 @@ class Plugin : public cs::core::PluginBase {
         std::string mTexture;
 
         /// The distance from the planet's center to where the ring starts in meters.
-        double mInnerRadius{};
+        double mInnerRadius;
 
         /// The distance from the planet's center to where the ring ends in meters.
-        double mOuterRadius{};
+        double mOuterRadius;
       };
 
       std::optional<Ring> mRing;

--- a/plugins/csp-simple-bodies/src/Plugin.hpp
+++ b/plugins/csp-simple-bodies/src/Plugin.hpp
@@ -13,6 +13,7 @@
 
 #include <map>
 #include <string>
+#include <optional>
 
 namespace csp::simplebodies {
 
@@ -27,6 +28,19 @@ class Plugin : public cs::core::PluginBase {
     struct SimpleBody {
       std::string                      mTexture;
       cs::utils::DefaultProperty<bool> mPrimeMeridianInCenter{true};
+
+      struct Ring {
+        /// The path to the texture. The texture should represent a cross section of the ring.
+        std::string mTexture;
+
+        /// The distance from the planets center to where the rings start in meter.
+        double mInnerRadius{};
+
+        /// The distance from the planets center to where the rings end in meter.
+        double mOuterRadius{};
+      };
+
+      std::optional<Ring> mRing;
     };
 
     std::map<std::string, SimpleBody> mSimpleBodies;

--- a/plugins/csp-simple-bodies/src/SimpleBody.cpp
+++ b/plugins/csp-simple-bodies/src/SimpleBody.cpp
@@ -12,7 +12,6 @@
 #include "../../../src/cs-graphics/TextureLoader.hpp"
 #include "../../../src/cs-utils/FrameStats.hpp"
 #include "../../../src/cs-utils/utils.hpp"
-#include "logger.hpp"
 
 #include <VistaKernel/GraphicsManager/VistaSceneGraph.h>
 #include <VistaKernel/GraphicsManager/VistaTransformNode.h>
@@ -206,13 +205,7 @@ float getRingShadow() {
 
     // Convert the distance to the texture coordinate.
     float texPosition = (dist - uRingRadii.x) / (uRingRadii.y - uRingRadii.x);
-
-    // We apply the same shading logic as in the rings plugin.
-    #ifdef ENABLE_HDR
-      return (1.0 - texture(uRingTexture, vec2(texPosition, 0.5)).a) * 0.5;
-    #else
-      return (1.0 - texture(uRingTexture, vec2(texPosition, 0.5)).a) * 2.0;
-    #endif
+    return 1.0 - texture(uRingTexture, vec2(texPosition, 0.5)).a;
   #else
     return 1.0;
   #endif

--- a/plugins/csp-simple-bodies/src/SimpleBody.cpp
+++ b/plugins/csp-simple-bodies/src/SimpleBody.cpp
@@ -160,7 +160,7 @@ float orenNayar(vec3 N, vec3 L, vec3 V) {
   return max(0, (L1 + L2) * cos_theta_i);
 }
 
-// Calculates the shading by planetary rings. This is done in x steps:
+// Calculates the shading by planetary rings. This is done in 3 steps:
 // 1. Calculate the intersection between a ray from the fragment to the Sun and the ring plane.
 // 2. If an intersection exists check if it falls within the ring.
 // 3. If it falls within the ring, we get the brightness from the ring texture.

--- a/plugins/csp-simple-bodies/src/SimpleBody.cpp
+++ b/plugins/csp-simple-bodies/src/SimpleBody.cpp
@@ -516,8 +516,10 @@ bool SimpleBody::Do() {
 
   if (mSimpleBodySettings.mRing) {
     mShader.SetUniform(mUniforms.ringRadii,
-        static_cast<float>(mSimpleBodySettings.mRing->mInnerRadius * parent->getScale() / mSolarSystem->getObserver().getScale()),
-        static_cast<float>(mSimpleBodySettings.mRing->mOuterRadius * parent->getScale() / mSolarSystem->getObserver().getScale()));
+        static_cast<float>(mSimpleBodySettings.mRing->mInnerRadius * parent->getScale() /
+                           mSolarSystem->getObserver().getScale()),
+        static_cast<float>(mSimpleBodySettings.mRing->mOuterRadius * parent->getScale() /
+                           mSolarSystem->getObserver().getScale()));
     mShader.SetUniform(mUniforms.ringTexture, 1);
     mRingTexture->Bind(GL_TEXTURE1);
   }

--- a/plugins/csp-simple-bodies/src/SimpleBody.hpp
+++ b/plugins/csp-simple-bodies/src/SimpleBody.hpp
@@ -19,6 +19,9 @@
 #include "../../../src/cs-core/Settings.hpp"
 #include "../../../src/cs-scene/CelestialSurface.hpp"
 #include "../../../src/cs-scene/IntersectableObject.hpp"
+
+#include <memory>
+
 #include "Plugin.hpp"
 
 namespace cs::core {
@@ -79,6 +82,8 @@ class SimpleBody : public cs::scene::CelestialSurface,
   VistaBufferObject             mSphereVBO;
   VistaBufferObject             mSphereIBO;
 
+  std::unique_ptr<VistaTexture> mRingTexture;
+
   cs::core::EclipseShadowReceiver mEclipseShadowReceiver;
 
   bool mShaderDirty = true;
@@ -95,6 +100,9 @@ class SimpleBody : public cs::scene::CelestialSurface,
     uint32_t projectionMatrix  = 0;
     uint32_t surfaceTexture    = 0;
     uint32_t radii             = 0;
+
+    uint32_t ringTexture       = 0;
+    uint32_t ringRadii         = 0;
   } mUniforms;
 
   static const char* SPHERE_VERT;

--- a/plugins/csp-simple-bodies/src/SimpleBody.hpp
+++ b/plugins/csp-simple-bodies/src/SimpleBody.hpp
@@ -100,7 +100,6 @@ class SimpleBody : public cs::scene::CelestialSurface,
     uint32_t projectionMatrix  = 0;
     uint32_t surfaceTexture    = 0;
     uint32_t radii             = 0;
-
     uint32_t ringTexture       = 0;
     uint32_t ringRadii         = 0;
   } mUniforms;


### PR DESCRIPTION
Simple bodies can now be shaded by their ring. They take the same config as the `csp-rings` plugin.

https://github.com/cosmoscout/cosmoscout-vr/assets/9581540/5f034843-47b0-4903-a982-b10da7634177


