### PR TITLE
Fix celestial object saving

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -51,6 +51,7 @@ SPDX-License-Identifier: CC-BY-4.0
 * In order to improve the rendering performance, the stars of `csp-stars` are not drawn anymore if the observer is on the day-side of a planet with an atmosphere.
 * The default exposure and glare values as well as the glare-slider mapping have been tweaked for a better appearance of the atmospheres in HDR mode.
 * The default star rendering mode has been changed to `eSmoothDisc`
+* When saving the scene with `CosmoScout.callbacks.core.save(...)`, optional properties of the celestial objects are not written anymore. This also fixes a warning about the Barycenter having no radii.
 
 #### Bug Fixes
 

--- a/src/cs-core/Settings.cpp
+++ b/src/cs-core/Settings.cpp
@@ -110,14 +110,31 @@ void to_json(nlohmann::json&                                                    
     cs::core::Settings::serialize(i, "center", object->getCenterName());
     cs::core::Settings::serialize(i, "frame", object->getFrameName());
     cs::core::Settings::serialize(i, "existence", object->getExistenceAsStrings());
-    cs::core::Settings::serialize(i, "position", object->getPosition());
-    cs::core::Settings::serialize(i, "rotation", object->getRotation());
-    cs::core::Settings::serialize(i, "size", object->getScale());
-    cs::core::Settings::serialize(i, "radii", object->getRadii());
-    cs::core::Settings::serialize(i, "bodyCullingRadius", object->getBodyCullingRadius());
-    cs::core::Settings::serialize(i, "orbitCullingRadius", object->getOrbitCullingRadius());
-    cs::core::Settings::serialize(i, "trackable", object->getIsTrackable());
-    cs::core::Settings::serialize(i, "collidable", object->getIsCollidable());
+
+    if (object->getPosition() != glm::dvec3(0.0, 0.0, 0.0)) {
+      cs::core::Settings::serialize(i, "position", object->getPosition());
+    }
+    if (object->getRotation() != glm::dquat(1.0, 0.0, 0.0, 0.0)) {
+      cs::core::Settings::serialize(i, "rotation", object->getRotation());
+    }
+    if (object->getScale() != 1.0) {
+      cs::core::Settings::serialize(i, "scale", object->getScale());
+    }
+    if (object->hasCustomRadii()) {
+      cs::core::Settings::serialize(i, "radii", object->getRadii());
+    }
+    if (object->getBodyCullingRadius() != 0) {
+      cs::core::Settings::serialize(i, "bodyCullingRadius", object->getBodyCullingRadius());
+    }
+    if (object->getOrbitCullingRadius() != 0) {
+      cs::core::Settings::serialize(i, "orbitCullingRadius", object->getOrbitCullingRadius());
+    }
+    if (!object->getIsTrackable()) {
+      cs::core::Settings::serialize(i, "trackable", object->getIsTrackable());
+    }
+    if (!object->getIsCollidable()) {
+      cs::core::Settings::serialize(i, "collidable", object->getIsCollidable());
+    }
 
     j[name] = i;
   }

--- a/src/cs-scene/CelestialObject.cpp
+++ b/src/cs-scene/CelestialObject.cpp
@@ -59,7 +59,7 @@ void CelestialObject::setExistenceAsStrings(std::array<std::string, 2> value) {
 
 glm::dvec3 const& CelestialObject::getRadii() const {
 
-  // If no radii were given to the object, we try once to get the from SPICE.
+  // If no radii were given to the object, we try once to get them from SPICE.
   if (mRadii == glm::dvec3(0.0) && mRadiiFromSPICE == glm::dvec3(-1.0)) {
     // get target id code
     SpiceInt     id{};
@@ -103,6 +103,12 @@ glm::dvec3 const& CelestialObject::getRadii() const {
 
 void CelestialObject::setRadii(glm::dvec3 value) {
   mRadii = std::move(value);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+bool CelestialObject::hasCustomRadii() const {
+  return mRadii != glm::dvec3(0.0);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/cs-scene/CelestialObject.hpp
+++ b/src/cs-scene/CelestialObject.hpp
@@ -58,6 +58,10 @@ class CS_SCENE_EXPORT CelestialObject : public CelestialAnchor {
   glm::dvec3 const& getRadii() const;
   void              setRadii(glm::dvec3 value);
 
+  /// Returns true if the radii of the object were set with setRadii() above to a different value
+  /// than [0.0, 0.0, 0.0].
+  bool hasCustomRadii() const;
+
   /// An approximate radius of the body in meters. This will serve as a basis for visibility
   /// calculation. If set to 0.0 (the default), getIsBodyVisible() will always return true.
   double getBodyCullingRadius() const;
@@ -164,8 +168,8 @@ class CS_SCENE_EXPORT CelestialObject : public CelestialAnchor {
   mutable std::shared_ptr<CelestialSurface>    mSurface;
   mutable std::shared_ptr<IntersectableObject> mIntersectable;
 
-  // This is mutable because the celestial will try to get its radii from SPICE in the first call to
-  // the otherwise const method getRadii().
+  // This is mutable because the celestial object will try to get its radii from SPICE in the first
+  // call to the otherwise const method getRadii().
   mutable glm::dvec3 mRadiiFromSPICE = glm::dvec3(-1.0);
 
   // These members are mutable as they have to be changed in the const update() method. They do not


### PR DESCRIPTION
 When saving the scene with `CosmoScout.callbacks.core.save(...)`, optional properties of the celestial objects are not written anymore. This also fixes a warning about the Barycenter having no radii when saving the scene.