### PR TITLE
Node Editor Improvements

### DIFF
--- a/plugins/csl-node-editor/gui/csl-node-editor.html
+++ b/plugins/csl-node-editor/gui/csl-node-editor.html
@@ -172,6 +172,9 @@ SPDX-License-Identifier: MIT
     // The comment below will be replaced with the combined source code of all registered nodes.
     //!NODE_SOURCE_CODE
 
+    // The comment below will be replaced with the combined source code of all registered controls.
+    //!CONTROL_SOURCE_CODE
+
     // Create the node editor ----------------------------------------------------------------------
 
     (async () => {

--- a/plugins/csl-node-editor/src/Node.hpp
+++ b/plugins/csl-node-editor/src/Node.hpp
@@ -36,6 +36,10 @@ class CSL_NODE_EDITOR_EXPORT Node {
   Node()          = default;
   virtual ~Node() = default;
 
+  /// This method gets called, once the node has been created and initialized. You can run some
+  /// initial logic here, that interacts with the JavaScript counterpart of this node.
+  virtual void init(){};
+
   /// Sends a custom message to the JavaScript counterpart of this node. The message can be received
   /// in the frontend with the onMessageFromCPP method of the node:
   ///   node.onMessageFromCPP = (message) => {

--- a/plugins/csl-node-editor/src/NodeEditor.cpp
+++ b/plugins/csl-node-editor/src/NodeEditor.cpp
@@ -87,6 +87,7 @@ NodeEditor::NodeEditor(uint16_t port, NodeFactory factory)
     // Replace the placeholders with the respective source code snippets.
     cs::utils::replaceString(html, "//!SOCKET_SOURCE_CODE", mFactory.getSocketSource());
     cs::utils::replaceString(html, "//!NODE_SOURCE_CODE", mFactory.getNodeSource());
+    cs::utils::replaceString(html, "//!CONTROL_SOURCE_CODE", mFactory.getControlSource());
     cs::utils::replaceString(html, "//!REGISTER_COMPONENTS", mFactory.getRegisterSource());
 
     mg_send_http_ok(conn, "text/html", html.length());

--- a/plugins/csl-node-editor/src/NodeEditor.cpp
+++ b/plugins/csl-node-editor/src/NodeEditor.cpp
@@ -162,6 +162,7 @@ void NodeEditor::update() {
         node->setPosition(position);
         node->setGraph(mGraph);
         node->setSocket(mSocket);
+        node->init();
 
         mGraph->addNode(id, std::move(node));
       } break;

--- a/plugins/csl-node-editor/src/NodeFactory.cpp
+++ b/plugins/csl-node-editor/src/NodeFactory.cpp
@@ -19,6 +19,12 @@ void NodeFactory::registerSocketType(std::string name, std::string color) {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
+void NodeFactory::registerControlType(const std::string& controlSource) {
+  mControls.emplace_back(controlSource);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
 std::string NodeFactory::getSocketSource() const {
   std::string source;
 
@@ -40,6 +46,20 @@ std::string NodeFactory::getNodeSource() const {
   // This concatenates all JavaScript source code snippets of the registered nodes.
   for (auto const& f : mNodeSourceFuncs) {
     source += f();
+  }
+
+  return source;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+std::string NodeFactory::getControlSource() const {
+  std::string source;
+
+  // This concatenates all JavaScript source code snippets of the registered nodes.
+  for (auto const& c : mControls) {
+    source += c;
+    source += '\n';
   }
 
   return source;

--- a/plugins/csl-node-editor/src/NodeFactory.cpp
+++ b/plugins/csl-node-editor/src/NodeFactory.cpp
@@ -19,8 +19,8 @@ void NodeFactory::registerSocketType(std::string name, std::string color) {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-void NodeFactory::registerControlType(const std::string& controlSource) {
-  mControls.emplace_back(controlSource);
+void NodeFactory::registerControlType(std::string controlSource) {
+  mControls.emplace_back(std::move(controlSource));
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/plugins/csl-node-editor/src/NodeFactory.hpp
+++ b/plugins/csl-node-editor/src/NodeFactory.hpp
@@ -46,7 +46,7 @@ class CSL_NODE_EDITOR_EXPORT NodeFactory {
   /// Register a new control type. The string should contain a JavaScript class that inherits from
   /// Rete.Control.
   /// @param controlSource The source code of a JavaScript class derived from Rete.Control.
-  void registerControlType(std::string const& controlSource);
+  void registerControlType(std::string controlSource);
 
   // Node Editor API -------------------------------------------------------------------------------
 

--- a/plugins/csl-node-editor/src/NodeFactory.hpp
+++ b/plugins/csl-node-editor/src/NodeFactory.hpp
@@ -22,7 +22,7 @@ class CSL_NODE_EDITOR_EXPORT NodeFactory {
  public:
   // public API ------------------------------------------------------------------------------------
 
-  // As a user of this library, you will usually only have to call the two methods below.
+  // As a user of this library, you will usually only have to call the three methods below.
 
   /// Registers a new node socket which can be used by nodes of the node editor.
   /// @param name     The unique name of the socket type. This is used to retrieve references to
@@ -43,6 +43,11 @@ class CSL_NODE_EDITOR_EXPORT NodeFactory {
     mNodeCreateFuncs[T::sName] = [=]() { return T::sCreate(args...); };
   }
 
+  /// Register a new control type. The string should contain a JavaScript class that inherits from
+  /// Rete.Control.
+  /// @param controlSource The source code of a JavaScript class derived from Rete.Control.
+  void registerControlType(std::string const& controlSource);
+
   // Node Editor API -------------------------------------------------------------------------------
 
   // The methods below are primarily meant to be used by the NodeEditor class. You may want use them
@@ -57,6 +62,11 @@ class CSL_NODE_EDITOR_EXPORT NodeFactory {
   /// setup all registered node types.
   /// @return The JavaScript source code.
   std::string getNodeSource() const;
+
+  /// This creates the JavaScript source snippet which is injected into the node editor web page to
+  /// setup all registered control types.
+  /// @return The JavaScript source code.
+  std::string getControlSource() const;
 
   /// This creates the JavaScript source snippet which is injected into the node editor web page to
   /// register all node types.
@@ -76,6 +86,9 @@ class CSL_NODE_EDITOR_EXPORT NodeFactory {
 
   // Functions to retrieve the JavaScript source of each registered node.
   std::vector<std::function<std::string(void)>> mNodeSourceFuncs;
+
+  // Source code for controls.
+  std::vector<std::string> mControls;
 
   // Functions to create new nodes for each type name.
   std::unordered_map<std::string, std::function<std::unique_ptr<Node>(void)>> mNodeCreateFuncs;

--- a/plugins/csp-demo-node-editor/CMakeLists.txt
+++ b/plugins/csp-demo-node-editor/CMakeLists.txt
@@ -18,11 +18,13 @@ file(GLOB NODE_FILES src/nodes/*.js)
 
 # Resoucre files and header files are only added in order to make them available in your IDE.
 file(GLOB HEADER_FILES src/*.hpp)
+file(GLOB_RECURSE CONTROL_FILES src/controls/*.js)
 
 add_library(csp-demo-node-editor SHARED
   ${SOURCE_FILES}
   ${HEADER_FILES}
   ${NODE_FILES}
+  ${CONTROL_FILES}
 )
 
 target_link_libraries(csp-demo-node-editor
@@ -36,13 +38,17 @@ set_property(TARGET csp-demo-node-editor PROPERTY FOLDER "plugins")
 # We mark all node source files as "header" in order to make sure that no one tries to compile them.
 set_source_files_properties(${NODE_FILES} PROPERTIES HEADER_FILE_ONLY TRUE)
 
+# We mark all control source files as "header" in order to make sure that no one tries to compile them.
+set_source_files_properties(${CONTROL_FILES} PROPERTIES HEADER_FILE_ONLY TRUE)
+
 # Make directory structure available in your IDE.
 source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}" FILES 
-  ${SOURCE_FILES} ${HEADER_FILES} ${NODE_FILES}
+  ${SOURCE_FILES} ${HEADER_FILES} ${NODE_FILES} ${CONTROL_FILES}
 )
 
 # install plugin -----------------------------------------------------------------------------------
 
 install(TARGETS csp-demo-node-editor  DESTINATION "share/plugins")
 install(FILES   ${NODE_FILES}         DESTINATION "share/resources/nodes/csp-demo-node-editor")
+install(FILES   ${CONTROL_FILES}      DESTINATION "share/resources/nodes/csp-demo-node-editor")
 

--- a/plugins/csp-demo-node-editor/src/Plugin.cpp
+++ b/plugins/csp-demo-node-editor/src/Plugin.cpp
@@ -9,6 +9,7 @@
 
 #include "../../../src/cs-core/Settings.hpp"
 
+#include "../../../src/cs-utils/filesystem.hpp"
 #include "logger.hpp"
 #include "nodes/DisplayNode.hpp"
 #include "nodes/MathNode.hpp"
@@ -119,6 +120,11 @@ void Plugin::setupNodeEditor(uint16_t port) {
   // color which will be used by the sockets. In this simple example, we only have number sockets.
   // The name of the socket will be used by the custom nodes when defining their inputs and outputs.
   factory.registerSocketType("Number Value", "#b08ab3");
+
+  // Here we can register controls, that can be used by our nodes. You can either load them from
+  // .js files or you can define them as a string.
+  factory.registerControlType(cs::utils::filesystem::loadToString(
+      "../share/resources/nodes/csp-demo-node-editor/TextDisplayControl.js"));
 
   // Now, we register our custom node types. Any parameter given to this method, will later be
   // passed to the constructor of the node instances. For more information, see the documentation of

--- a/plugins/csp-demo-node-editor/src/controls/TextDisplayControl.js
+++ b/plugins/csp-demo-node-editor/src/controls/TextDisplayControl.js
@@ -1,0 +1,42 @@
+////////////////////////////////////////////////////////////////////////////////////////////////////
+//                               This file is part of CosmoScout VR                               //
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// SPDX-FileCopyrightText: German Aerospace Center (DLR) <cosmoscout@dlr.de>
+// SPDX-License-Identifier: MIT
+
+// This is the widget which is used for displaying text data.
+class TextDisplayControl extends Rete.Control {
+  constructor(key, initialValue = '') {
+    super(key);
+
+    // This HTML code will be used whenever a node is created with this widget.
+    this.template = `
+          <p class="text-value">${initialValue}</p>
+
+          <style>
+            p.text-value {
+              font-family: 'Ubuntu Mono', monospace;
+              border-radius: var(--cs-border-radius-medium);
+              background: rgba(255, 255, 255, 0.1);
+              width: 200px;
+              padding: 5px 15px;
+              margin: 10px;
+              text-align: right;
+              font-size: 1.1em;
+            }
+          </style>
+        `;
+  }
+
+  // This can be called by the node.onMessageFromCPP method whenever a new value is sent in from
+  // C++.
+  setValue(val) {
+
+    // Each node container gets the id "#node-<id>". This way we can select elements inside the
+    // node using a selector. Here we select the p element with the class "text-value" as
+    // defined by the template above.
+    const el     = document.querySelector("#node-" + this.parent.id + " .text-value");
+    el.innerHTML = val;
+  }
+}

--- a/plugins/csp-demo-node-editor/src/nodes/DisplayNode.js
+++ b/plugins/csp-demo-node-editor/src/nodes/DisplayNode.js
@@ -29,8 +29,8 @@ class DisplayComponent extends Rete.Component {
     node.addInput(input);
 
     // Add the number display. The name parameter must be unique amongst all controls of this
-    // node. The DisplayControl class is defined further below.
-    let control = new DisplayControl('display');
+    // node. The TextDisplayControl class is defined in the controls folder.
+    let control = new TextDisplayControl('display', '0');
     node.addControl(control);
 
     // Whenever a message from C++ arrives, we set the input value accordingly. This message is
@@ -38,41 +38,5 @@ class DisplayComponent extends Rete.Component {
     node.onMessageFromCPP = (message) => { control.setValue(message.value); };
 
     return node;
-  }
-}
-
-// This is the widget which is used for displaying the data.
-class DisplayControl extends Rete.Control {
-  constructor(key) {
-    super(key);
-
-    // This HTML code will be used whenever a node is created with this widget.
-    this.template = `
-          <p class="display-value">0</p>
-
-          <style>
-            p.display-value {
-              font-family: 'Ubuntu Mono', monospace;
-              border-radius: var(--cs-border-radius-medium);
-              background: rgba(255, 255, 255, 0.1);
-              width: 200px;
-              padding: 5px 15px;
-              margin: 10px;
-              text-align: right;
-              font-size: 1.1em;
-            }
-          </style>
-        `;
-  }
-
-  // This is called by the node.onMessageFromCPP method above whenever a new value is sent in
-  // from C++.
-  setValue(val) {
-
-    // Each node container gets the id "#node-<id>". This way we can select elements inside the
-    // node using a selector. Here we select the p element with the class "display-value" as
-    // defined by the template above.
-    const el     = document.querySelector("#node-" + this.parent.id + " .display-value");
-    el.innerHTML = val;
   }
 }

--- a/plugins/csp-demo-node-editor/src/nodes/TimeNode.cpp
+++ b/plugins/csp-demo-node-editor/src/nodes/TimeNode.cpp
@@ -8,6 +8,7 @@
 #include "TimeNode.hpp"
 
 #include "../../../../src/cs-core/TimeControl.hpp"
+#include "../../../../src/cs-utils/convert.hpp"
 #include "../../../../src/cs-utils/filesystem.hpp"
 
 namespace csp::demonodeeditor {
@@ -54,7 +55,16 @@ std::string const& TimeNode::getName() const {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
+void TimeNode::init() {
+  sendMessageToJS(boost::posix_time::to_simple_string(
+      cs::utils::convert::time::toPosix(mTimeControl->pSimulationTime.get())));
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
 void TimeNode::process() {
+  sendMessageToJS(boost::posix_time::to_simple_string(
+      cs::utils::convert::time::toPosix(mTimeControl->pSimulationTime.get())));
 
   // The name of the port must match the name given in the JavaScript code above.
   writeOutput("time", mTimeControl->pSimulationTime.get());

--- a/plugins/csp-demo-node-editor/src/nodes/TimeNode.hpp
+++ b/plugins/csp-demo-node-editor/src/nodes/TimeNode.hpp
@@ -35,6 +35,10 @@ class TimeNode : public csl::nodeeditor::Node {
   explicit TimeNode(std::shared_ptr<cs::core::TimeControl> timeControl);
   ~TimeNode() override;
 
+  /// This function gets called once after the node has been initialized. You can use it to send
+  /// initialization data to JavaScript.
+  void init() override;
+
   /// Each node must override this. It simply returns the static sName.
   std::string const& getName() const override;
 

--- a/plugins/csp-demo-node-editor/src/nodes/TimeNode.js
+++ b/plugins/csp-demo-node-editor/src/nodes/TimeNode.js
@@ -28,6 +28,51 @@ class TimeComponent extends Rete.Component {
     let output = new Rete.Output('time', "Seconds", CosmoScout.socketTypes['Number Value']);
     node.addOutput(output)
 
+    // Add the time display. The name parameter must be unique amongst all controls of this
+    // node. The TimeDisplayControl class is defined further below.
+    let control = new TimeDisplayControl('display');
+    node.addControl(control);
+
+    // Whenever a message from C++ arrives, we set the input value accordingly. This message is
+    // sent by the TimeNode::init() and TimeNode::process() methods.
+    node.onMessageFromCPP = (timeString) => { control.setValue(timeString); };
+
     return node;
+  }
+}
+
+// This is the widget which is used for displaying the time data.
+class TimeDisplayControl extends Rete.Control {
+  constructor(key) {
+    super(key);
+
+    // This HTML code will be used whenever a node is created with this widget.
+    this.template = `
+          <p class="display-value"></p>
+
+          <style>
+            p.display-value {
+              font-family: 'Ubuntu Mono', monospace;
+              border-radius: var(--cs-border-radius-medium);
+              background: rgba(255, 255, 255, 0.1);
+              width: 200px;
+              padding: 5px 15px;
+              margin: 10px;
+              text-align: right;
+              font-size: 1.1em;
+            }
+          </style>
+        `;
+  }
+
+  // This is called by the node.onMessageFromCPP method above whenever a new value is sent in
+  // from C++.
+  setValue(val) {
+
+    // Each node container gets the id "#node-<id>". This way we can select elements inside the
+    // node using a selector. Here we select the p element with the class "display-value" as
+    // defined by the template above.
+    const el     = document.querySelector("#node-" + this.parent.id + " .display-value");
+    el.innerHTML = val;
   }
 }

--- a/plugins/csp-demo-node-editor/src/nodes/TimeNode.js
+++ b/plugins/csp-demo-node-editor/src/nodes/TimeNode.js
@@ -29,8 +29,8 @@ class TimeComponent extends Rete.Component {
     node.addOutput(output)
 
     // Add the time display. The name parameter must be unique amongst all controls of this
-    // node. The TimeDisplayControl class is defined further below.
-    let control = new TimeDisplayControl('display');
+    // node. The TextDisplayControl class is defined in the controls folder.
+    let control = new TextDisplayControl('display');
     node.addControl(control);
 
     // Whenever a message from C++ arrives, we set the input value accordingly. This message is
@@ -38,41 +38,5 @@ class TimeComponent extends Rete.Component {
     node.onMessageFromCPP = (timeString) => { control.setValue(timeString); };
 
     return node;
-  }
-}
-
-// This is the widget which is used for displaying the time data.
-class TimeDisplayControl extends Rete.Control {
-  constructor(key) {
-    super(key);
-
-    // This HTML code will be used whenever a node is created with this widget.
-    this.template = `
-          <p class="display-value"></p>
-
-          <style>
-            p.display-value {
-              font-family: 'Ubuntu Mono', monospace;
-              border-radius: var(--cs-border-radius-medium);
-              background: rgba(255, 255, 255, 0.1);
-              width: 200px;
-              padding: 5px 15px;
-              margin: 10px;
-              text-align: right;
-              font-size: 1.1em;
-            }
-          </style>
-        `;
-  }
-
-  // This is called by the node.onMessageFromCPP method above whenever a new value is sent in
-  // from C++.
-  setValue(val) {
-
-    // Each node container gets the id "#node-<id>". This way we can select elements inside the
-    // node using a selector. Here we select the p element with the class "display-value" as
-    // defined by the template above.
-    const el     = document.querySelector("#node-" + this.parent.id + " .display-value");
-    el.innerHTML = val;
   }
 }


### PR DESCRIPTION
This PR adds two new features to the csl-node-editor and implements them in the csp-demo-node-editor.
1. `csl::nodeeditor::Node` now has a virtual `init()` function which can be implemented to do some initialization directly after the node is in a valid state.
2. Add a function to the `csl::nodeditor::NodeFactory` to register `Rete.Control` sublcasses, so they can be reused by multiple nodes.