### PR TITLE
Fix lod body loading

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,14 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # Changelog of CosmoScout VR
 
+## [unreleased]
+
+**Release Date:** TBD
+
+#### Bug Fixes
+
+* Fixed invalid terrain height of LoD bodies after reloading of the scene settings.
+
 ## [v1.9.0](https://github.com/cosmoscout/cosmoscout-vr/releases)
 
 **Release Date:** 2024-01-30

--- a/plugins/csp-lod-bodies/src/Plugin.cpp
+++ b/plugins/csp-lod-bodies/src/Plugin.cpp
@@ -532,8 +532,14 @@ void Plugin::onLoad() {
   // Then add new lodBodies.
   for (auto const& settings : mPluginSettings->mBodies) {
 
-    // Skip already existing bodies.
-    if (mLodBodies.find(settings.first) != mLodBodies.end()) {
+    auto object = mSolarSystem->getObject(settings.first);
+
+    // Skip already existing bodies. Only make sure that they are registered as surface and
+    // intersectable object.
+    auto existingBody = mLodBodies.find(settings.first);
+    if (existingBody != mLodBodies.end()) {
+      object->setSurface(existingBody->second);
+      object->setIntersectableObject(existingBody->second);
       continue;
     }
 
@@ -542,7 +548,6 @@ void Plugin::onLoad() {
 
     body->setObjectName(settings.first);
 
-    auto object = mSolarSystem->getObject(settings.first);
     object->setSurface(body);
     object->setIntersectableObject(body);
 


### PR DESCRIPTION
This PR ensures that LoD bodies are properly re-registered as CelestialSurfaces after reloading the settings.