### PR TITLE
Enable vista text rendering

### DIFF
--- a/config/base/vista/display.ini
+++ b/config/base/vista/display.ini
@@ -46,3 +46,9 @@ PROJ_PLANE_MIDPOINT = 0, 0, -7.0
 PROJ_PLANE_EXTENTS  = -5.333, 5.333, -3.0, 3.0
 CLIPPING_RANGE      = 0.5, 5000
 STEREO_MODE         = MONO
+
+
+####################### SDL2 Text Overlay Fonts #######################
+
+[FONTS]
+SANS_FONT           = ../share/resources/gui/third-party/fonts/Ubuntu-R.ttf

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,10 @@ SPDX-License-Identifier: CC-BY-4.0
 
 **Release Date:** TBD
 
+#### Other Changes
+
+* It is now possible to use the vista debug text rendering again.
+
 #### Bug Fixes
 
 * Fixed invalid terrain height of LoD bodies after reloading of the scene settings.


### PR DESCRIPTION
This fixes rendering bugs caused by text rendering in vista and adds a font to the vista config by default.