### PR TITLE
Add callback for hot reloading DFNs

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,7 @@ SPDX-License-Identifier: CC-BY-4.0
 #### Other Changes
 
 * It is now possible to use the vista debug text rendering again.
+* New callback `CosmoScout.callbacks.input.reloadDFNs()` to hot reload DFN xml files.
 
 #### Bug Fixes
 

--- a/src/cosmoscout/Application.cpp
+++ b/src/cosmoscout/Application.cpp
@@ -1685,6 +1685,21 @@ void Application::registerGuiCallbacks() {
         mSolarSystem->flyObserverTo(mSolarSystem->getObserver().getCenterName(),
             mSolarSystem->getObserver().getFrameName(), cart, rotation, duration.value_or(3.0));
       }));
+
+      
+  mGuiManager->getGui()->registerCallback("input.reloadDFNs",
+      "Reloads the DFNs. This can be used to hot reload the DFNs, when editing the interaction"
+      "xml files.",
+      std::function([] {
+        auto* interactionManager = GetVistaSystem()->GetInteractionManager();
+        auto  numContexts        = interactionManager->GetNumInteractionContexts();
+
+        for (int i = 0; i < numContexts; ++i) {
+          auto* context = interactionManager->GetInteractionContext(i);
+          interactionManager->ReloadGraphForContext(
+              context, GetVistaSystem()->GetClusterMode()->GetNodeName());
+      }
+  }));
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1724,6 +1739,7 @@ void Application::unregisterGuiCallbacks() {
   mGuiManager->getGui()->unregisterCallback("graphics.setGlareQuality");
   mGuiManager->getGui()->unregisterCallback("graphics.setExposureRange");
   mGuiManager->getGui()->unregisterCallback("graphics.setFixedSunDirection");
+  mGuiManager->getGui()->unregisterCallback("input.reloadDFNs");
   mGuiManager->getGui()->unregisterCallback("navigation.fixHorizon");
   mGuiManager->getGui()->unregisterCallback("navigation.northUp");
   mGuiManager->getGui()->unregisterCallback("navigation.setBody");

--- a/src/cosmoscout/Application.cpp
+++ b/src/cosmoscout/Application.cpp
@@ -1687,7 +1687,6 @@ void Application::registerGuiCallbacks() {
             mSolarSystem->getObserver().getFrameName(), cart, rotation, duration.value_or(3.0));
       }));
 
-      
   mGuiManager->getGui()->registerCallback("input.reloadDFNs",
       "Reloads the DFNs. This can be used to hot reload the DFNs, when editing the interaction"
       "xml files.",
@@ -1699,8 +1698,8 @@ void Application::registerGuiCallbacks() {
           auto* context = interactionManager->GetInteractionContext(i);
           interactionManager->ReloadGraphForContext(
               context, GetVistaSystem()->GetClusterMode()->GetNodeName());
-      }
-  }));
+        }
+      }));
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/cosmoscout/Application.cpp
+++ b/src/cosmoscout/Application.cpp
@@ -37,6 +37,7 @@
 #include <VistaKernel/EventManager/VistaSystemEvent.h>
 #include <VistaKernel/GraphicsManager/VistaSceneGraph.h>
 #include <VistaKernel/GraphicsManager/VistaTransformNode.h>
+#include <VistaKernel/InteractionManager/VistaInteractionManager.h>
 #include <VistaKernel/VistaSystem.h>
 #include <VistaOGLExt/VistaShaderRegistry.h>
 #include <curlpp/cURLpp.hpp>


### PR DESCRIPTION
Added a callback `CosmoScout.callbacks.input.reloadDFNs()` to hot reload DFN xml files.

You can easily test it by doing the following:
1. Start CosmoScout VR
2. Move around with "W A S D"
3. Change the keys in the "keyboard_navigation.xml" from "w a s d" to "i j k l"
4. Type `CosmoScout.callbacks.input.reloadDFNs()` into the JS console.
5. Try moving around with "I J K L", instead of "W A S D"