### PR TITLE
Add fixed_horizon option to the ObserverNavigationNode

### DIFF
--- a/src/cosmoscout/ObserverNavigationNode.hpp
+++ b/src/cosmoscout/ObserverNavigationNode.hpp
@@ -49,6 +49,7 @@ class ObserverNavigationNode : public IVdfnNode {
   TVdfnPort<VistaVector3D>*   mOffset;
 
   const bool          mPreventNavigationWhenHoveredGui;
+  const bool          mFixedHorizon;
   const double        mMaxAngularSpeed;
   const VistaVector3D mMaxLinearSpeed;
 


### PR DESCRIPTION
This adds a `fixed_horizon` parameter to the ObserNavigationNode. If this is set to `true`, the observer is always rotated so that the horizon of the active object is always leveled.

For now, this breaks if we are in outer space or looking straight up or down. But it can already be very useful in cases were we know that the user is always close to a planet.

In the future, we could try making this work in outer space as well by checking the distance to the active object and gradually transitioning to the fixed horizon based on the distance.

You can enable this in DFN like this:

```xml
<node name="observer" type="ObserverNavigationNode">
   <param name="fixed_horizon" value="true" />
</node>
```