### PR TITLE
Disable depth-write for trajectories

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 #### Other Changes
 
+- The depth-write for trajectory lines has been disabled. This improves their rendering on many GPUs. They are now not always correctly composited with transparent objects, but this will produce only minor artifacts in most cases.
 - It is now possible to use the vista debug text rendering again.
 - New callback `CosmoScout.callbacks.input.reloadDFNs()` to hot reload DFN xml files.
 - The preprocessing of the Bruneton atmosphere model has been refactored to a standalone tool. This tool can now be used to generate the necessary data offline and thus improves the start-up time of CosmoScout VR significantly.

--- a/src/cs-scene/Trajectory.cpp
+++ b/src/cs-scene/Trajectory.cpp
@@ -138,6 +138,8 @@ bool Trajectory::Do() {
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     glEnable(GL_LINE_SMOOTH);
     glHint(GL_LINE_SMOOTH_HINT, GL_NICEST);
+    glDepthMask(GL_FALSE);
+    glLineWidth(mWidth);
 
     mVAO->Bind();
     mShader->Bind();
@@ -154,15 +156,7 @@ bool Trajectory::Do() {
     glUniformMatrix4fv(mUniforms.modelViewMatrix, 1, GL_FALSE, glMatMV.data());
     glUniformMatrix4fv(mUniforms.projectionMatrix, 1, GL_FALSE, glMatP.data());
 
-    glLineWidth(mWidth);
-
-    uint32_t amountNoDepth = mPointCount / 2;
-
-    glDepthMask(GL_FALSE);
-    glDrawArrays(GL_LINE_STRIP, 0, amountNoDepth + 1);
-    glDepthMask(GL_TRUE);
-
-    glDrawArrays(GL_LINE_STRIP, amountNoDepth, mPointCount - amountNoDepth);
+    glDrawArrays(GL_LINE_STRIP, 0, mPointCount);
 
     mShader->Release();
     mVAO->Release();


### PR DESCRIPTION
Currently, we write depth for the first half of a trajectory line. This enables better draw-order compositing with other transparent objects but produces severe artifacts on some (non-Quadro?) GPUs.

This PR disables depth write for trajectories altogether. This improves rendering on many GPUs. Now, trajectory lines are now not always correctly composited with transparent objects, but this will be visible only in very rare cases.

Before | After
-------|------
![Screenshot from 2024-11-13 09-18-55](https://github.com/user-attachments/assets/6fbd52d8-cd18-427b-ab3d-55720c472419) | ![Screenshot from 2024-11-13 09-17-26](https://github.com/user-attachments/assets/dbff779e-a233-4e40-801b-1c6e9dc08fba)

A better (but significantly more complex) solution would be to draw the trajectories using triangles instead of the very fragile smoothed GL lines. But I think that this solution is a simple improvement for now.
