### PR TITLE
Evaluate Bi-Cubic Glare-Interpolation in Compute-Preprocess for

### DIFF
--- a/resources/shaders/glare.comp
+++ b/resources/shaders/glare.comp
@@ -27,17 +27,20 @@ const float PI = 3.14159265359;
 // the pixel position in the base layer of the output mipmap pyramid.
 // For performance reasons, we only use one sample for multisample inputs.
 vec3 sampleHDRBuffer(ivec2 pos) {
+  ivec2 pos_times_two = pos << 1;
+
 #if NUM_MULTISAMPLES > 0
-  vec3 col = imageLoad(uInHDRBuffer, ivec2(pos * 2 + ivec2(0, 0)), 0).rgb * 0.25 +
-             imageLoad(uInHDRBuffer, ivec2(pos * 2 + ivec2(1, 0)), 0).rgb * 0.25 +
-             imageLoad(uInHDRBuffer, ivec2(pos * 2 + ivec2(0, 1)), 0).rgb * 0.25 +
-             imageLoad(uInHDRBuffer, ivec2(pos * 2 + ivec2(1, 1)), 0).rgb * 0.25;
+  vec3 col = imageLoad(uInHDRBuffer, ivec2(pos_times_two + ivec2(0, 0)), 0).rgb +
+             imageLoad(uInHDRBuffer, ivec2(pos_times_two + ivec2(1, 0)), 0).rgb +
+             imageLoad(uInHDRBuffer, ivec2(pos_times_two + ivec2(0, 1)), 0).rgb +
+             imageLoad(uInHDRBuffer, ivec2(pos_times_two + ivec2(1, 1)), 0).rgb;
 #else
-  vec3 col = imageLoad(uInHDRBuffer, ivec2(pos * 2 + ivec2(0, 0))).rgb * 0.25 +
-             imageLoad(uInHDRBuffer, ivec2(pos * 2 + ivec2(1, 0))).rgb * 0.25 +
-             imageLoad(uInHDRBuffer, ivec2(pos * 2 + ivec2(0, 1))).rgb * 0.25 +
-             imageLoad(uInHDRBuffer, ivec2(pos * 2 + ivec2(1, 1))).rgb * 0.25;
+  vec3 col = imageLoad(uInHDRBuffer, ivec2(pos_times_two + ivec2(0, 0))).rgb +
+             imageLoad(uInHDRBuffer, ivec2(pos_times_two + ivec2(1, 0))).rgb +
+             imageLoad(uInHDRBuffer, ivec2(pos_times_two + ivec2(0, 1))).rgb +
+             imageLoad(uInHDRBuffer, ivec2(pos_times_two + ivec2(1, 1))).rgb;
 #endif
+  col *= 0.25;
   return col;
 }
 
@@ -58,10 +61,12 @@ vec3 sampleHDRBuffer(vec2 pos) {
 // Makes four texture look-ups in the input layer of the glare mipmap at the four pixels
 // corresponding to the pixel position in the current layer of the mipmap pyramid.
 vec3 sampleHigherLevel(ivec2 pos) {
-  vec3 col = imageLoad(uInGlare, ivec2(pos * 2 + ivec2(0, 0))).rgb * 0.25 +
-             imageLoad(uInGlare, ivec2(pos * 2 + ivec2(1, 0))).rgb * 0.25 +
-             imageLoad(uInGlare, ivec2(pos * 2 + ivec2(0, 1))).rgb * 0.25 +
-             imageLoad(uInGlare, ivec2(pos * 2 + ivec2(1, 1))).rgb * 0.25;
+  ivec2 pos_times_two = pos << 1;
+  vec3 col = imageLoad(uInGlare, ivec2(pos_times_two + ivec2(0, 0))).rgb +
+             imageLoad(uInGlare, ivec2(pos_times_two + ivec2(1, 0))).rgb +
+             imageLoad(uInGlare, ivec2(pos_times_two + ivec2(0, 1))).rgb +
+             imageLoad(uInGlare, ivec2(pos_times_two + ivec2(1, 1))).rgb;
+  col *= 0.25;
   return col;
 }
 

--- a/resources/shaders/glareComposite.comp
+++ b/resources/shaders/glareComposite.comp
@@ -9,7 +9,7 @@
 
 layout(local_size_x = 16, local_size_y = 16) in;
 
-layout(rgba32f, binding = 1) readonly uniform image2D uInGlare;
+layout(binding = 0) uniform sampler2D uGlareMipMap;
 layout(rgba32f, binding = 2) writeonly uniform image2D uOutGlare;
 
 void main() {
@@ -22,6 +22,7 @@ void main() {
     return;
   }
 
+  vec3 sampled_glare_base_level_values = texelFetch(uGlareMipMap, pixelPos, 0).rgb;
   // Finally store the glare value in the output layer of the glare mipmap.
-  imageStore(uOutGlare, pixelPos, vec4(1.0, 0.0, 0.0, 0.0));
+  imageStore(uOutGlare, pixelPos, vec4(sampled_glare_base_level_values, 0.0));
 }

--- a/resources/shaders/glareComposite.comp
+++ b/resources/shaders/glareComposite.comp
@@ -10,6 +10,71 @@ layout(local_size_x = 16, local_size_y = 16) in;
 layout(binding = 0) uniform sampler2D uGlareMipMap;
 layout(rgba32f, binding = 2) writeonly uniform image2D uOutGlare;
 
+
+// 4x4 bicubic filter using 4 bilinear texture lookups
+// See GPU Gems 2: "Fast Third-Order Texture Filtering", Sigg & Hadwiger:
+// http://http.developer.nvidia.com/GPUGems2/gpugems2_chapter20.html
+
+// w0, w1, w2, and w3 are the four cubic B-spline basis functions
+float w0(float a) {
+  return (1.0 / 6.0) * (a * (a * (-a + 3.0) - 3.0) + 1.0);
+}
+
+float w1(float a) {
+  return (1.0 / 6.0) * (a * a * (3.0 * a - 6.0) + 4.0);
+}
+
+float w2(float a) {
+  return (1.0 / 6.0) * (a * (a * (-3.0 * a + 3.0) + 3.0) + 1.0);
+}
+
+float w3(float a) {
+  return (1.0 / 6.0) * (a * a * a);
+}
+
+// g0 and g1 are the two amplitude functions
+float g0(float a) {
+  return w0(a) + w1(a);
+}
+
+float g1(float a) {
+  return w2(a) + w3(a);
+}
+
+// h0 and h1 are the two offset functions
+float h0(float a) {
+  return -1.0 + w1(a) / (w0(a) + w1(a));
+}
+
+float h1(float a) {
+  return 1.0 + w3(a) / (w2(a) + w3(a));
+}
+
+vec4 texture2D_bicubic(sampler2D tex, vec2 uv, int p_lod) {
+  float lod        = float(p_lod);
+  vec2  tex_size   = textureSize(uGlareMipMap, p_lod);
+  vec2  pixel_size = 1.0 / tex_size;
+  uv               = uv * tex_size + 0.5;
+  vec2 iuv         = floor(uv);
+  vec2 fuv         = fract(uv);
+
+  float g0x = g0(fuv.x);
+  float g1x = g1(fuv.x);
+  float h0x = h0(fuv.x);
+  float h1x = h1(fuv.x);
+  float h0y = h0(fuv.y);
+  float h1y = h1(fuv.y);
+
+  vec2 p0 = (vec2(iuv.x + h0x, iuv.y + h0y) - 0.5) * pixel_size;
+  vec2 p1 = (vec2(iuv.x + h1x, iuv.y + h0y) - 0.5) * pixel_size;
+  vec2 p2 = (vec2(iuv.x + h0x, iuv.y + h1y) - 0.5) * pixel_size;
+  vec2 p3 = (vec2(iuv.x + h1x, iuv.y + h1y) - 0.5) * pixel_size;
+
+  return (g0(fuv.y) * (g0x * textureLod(tex, p0, lod) + g1x * textureLod(tex, p1, lod))) +
+         (g1(fuv.y) * (g0x * textureLod(tex, p2, lod) + g1x * textureLod(tex, p3, lod)));
+}
+
+
 void main() {
 
   ivec2 pixelPos   = ivec2(gl_GlobalInvocationID.xy);
@@ -20,7 +85,37 @@ void main() {
     return;
   }
 
-  vec3 sampled_glare_base_level_values = texelFetch(uGlareMipMap, pixelPos, 0).rgb;
-  // Finally store the glare value in the output layer of the glare mipmap.
-  imageStore(uOutGlare, pixelPos, vec4(1.0*GLARE_INTENSITY, 0.0, 0.0, 0.0));
+
+    if (GLARE_INTENSITY > 0.0) {
+
+        vec3  glare     = vec3(0);
+        float maxLevels = textureQueryLevels(uGlareMipMap);
+
+        float totalWeight = 0;
+
+
+        vec2  vTexcoords   = (pixelPos + vec2(0.5)) / textureSize(uGlareMipMap, 0);
+
+        // Each level contains a successively more blurred version of the scene. We have to
+        // accumulate them with an exponentially decreasing weight to get a proper glare distribution.
+        for (int i = 0; i < maxLevels; ++i) {
+          float weight = 1.0 / pow(2, i);
+
+
+          glare += texture2D_bicubic(uGlareMipMap, vTexcoords, i).rgb * weight;
+
+
+          totalWeight += weight;
+        }
+
+        vec3 final_glare_value = glare / totalWeight;
+
+
+
+    //vec3 sampled_glare_base_level_values = texelFetch(uGlareMipMap, pixelPos, 0).rgb;
+    // Finally store the glare value in the output layer of the glare mipmap.
+    imageStore(uOutGlare, pixelPos, vec4(final_glare_value, 0.0));
+  } else {
+    imageStore(uOutGlare, pixelPos, vec4(0.0, 0.0, 0.0, 0.0));
+  }
 }

--- a/resources/shaders/glareComposite.comp
+++ b/resources/shaders/glareComposite.comp
@@ -5,8 +5,6 @@
 // SPDX-FileCopyrightText: German Aerospace Center (DLR) <cosmoscout@dlr.de>
 // SPDX-License-Identifier: MIT
 
-#version 430
-
 layout(local_size_x = 16, local_size_y = 16) in;
 
 layout(binding = 0) uniform sampler2D uGlareMipMap;

--- a/resources/shaders/glareComposite.comp
+++ b/resources/shaders/glareComposite.comp
@@ -85,37 +85,25 @@ void main() {
     return;
   }
 
+  vec3  glare     = vec3(0);
+  float maxLevels = textureQueryLevels(uGlareMipMap);
 
-    if (GLARE_INTENSITY > 0.0) {
-
-        vec3  glare     = vec3(0);
-        float maxLevels = textureQueryLevels(uGlareMipMap);
-
-        float totalWeight = 0;
+  float totalWeight = 0;
 
 
-        vec2  vTexcoords   = (pixelPos + vec2(0.5)) / textureSize(uGlareMipMap, 0);
+  vec2  vTexcoords   = (pixelPos + vec2(0.5)) / textureSize(uGlareMipMap, 0);
 
-        // Each level contains a successively more blurred version of the scene. We have to
-        // accumulate them with an exponentially decreasing weight to get a proper glare distribution.
-        for (int i = 0; i < maxLevels; ++i) {
-          float weight = 1.0 / pow(2, i);
-
-
-          glare += texture2D_bicubic(uGlareMipMap, vTexcoords, i).rgb * weight;
-
-
-          totalWeight += weight;
-        }
-
-        vec3 final_glare_value = glare / totalWeight;
-
-
-
-    //vec3 sampled_glare_base_level_values = texelFetch(uGlareMipMap, pixelPos, 0).rgb;
-    // Finally store the glare value in the output layer of the glare mipmap.
-    imageStore(uOutGlare, pixelPos, vec4(final_glare_value, 0.0));
-  } else {
-    imageStore(uOutGlare, pixelPos, vec4(0.0, 0.0, 0.0, 0.0));
+  // Each level contains a successively more blurred version of the scene. We have to
+  // accumulate them with an exponentially decreasing weight to get a proper glare distribution.
+  for (int i = 0; i < maxLevels; ++i) {
+    float weight = 1.0 / (1 << i);
+    glare += texture2D_bicubic(uGlareMipMap, vTexcoords, i).rgb * weight;
+    totalWeight += weight;
   }
+
+  vec3 final_glare_value = glare / totalWeight;
+
+  //vec3 sampled_glare_base_level_values = texelFetch(uGlareMipMap, pixelPos, 0).rgb;
+  // Finally store the glare value in the output layer of the glare mipmap.
+  imageStore(uOutGlare, pixelPos, vec4(final_glare_value, 0.0));
 }

--- a/resources/shaders/glareComposite.comp
+++ b/resources/shaders/glareComposite.comp
@@ -22,5 +22,5 @@ void main() {
 
   vec3 sampled_glare_base_level_values = texelFetch(uGlareMipMap, pixelPos, 0).rgb;
   // Finally store the glare value in the output layer of the glare mipmap.
-  imageStore(uOutGlare, pixelPos, vec4(sampled_glare_base_level_values, 0.0));
+  imageStore(uOutGlare, pixelPos, vec4(1.0*GLARE_INTENSITY, 0.0, 0.0, 0.0));
 }

--- a/resources/shaders/tonemap.frag
+++ b/resources/shaders/tonemap.frag
@@ -130,6 +130,14 @@ void main() {
 #endif
 
   if (uGlareIntensity > 0) {
+#ifdef BICUBIC_GLARE_FILTER
+
+      vec3 glare = texture2D(uGlareMipMap, vTexcoords, 0).rgb;
+
+      color = mix(color, glare, pow(uGlareIntensity, 2.0));
+#else
+
+
     vec3  glare     = vec3(0);
     float maxLevels = textureQueryLevels(uGlareMipMap);
 
@@ -140,17 +148,17 @@ void main() {
     for (int i = 0; i < maxLevels; ++i) {
       float weight = 1.0 / pow(2, i);
 
-#ifdef BICUBIC_GLARE_FILTER
-      glare += texture2D_bicubic(uGlareMipMap, vTexcoords, i).rgb * weight;
-#else
+
       glare += texture2D(uGlareMipMap, vTexcoords, i).rgb * weight;
-#endif
+
 
       totalWeight += weight;
     }
 
     // To make sure that we do not add energy, we divide by the total weight.
     color = mix(color, glare / totalWeight, pow(uGlareIntensity, 2.0));
+#endif
+
   }
 
 // Filmic

--- a/src/cs-core/GraphicsEngine.cpp
+++ b/src/cs-core/GraphicsEngine.cpp
@@ -189,7 +189,7 @@ GraphicsEngine::GraphicsEngine(std::shared_ptr<core::Settings> settings)
 
   mSettings->mGraphics.pGlareIntensity.connectAndTouch(
       [this](float val) { mToneMappingNode->setGlareIntensity(val);
-                          mHDRBuffer->setGlareQuality(val);});
+                          mHDRBuffer->setGlareIntensity(val);});
 
   mSettings->mGraphics.pGlareQuality.connectAndTouch(
       [this](uint32_t val) { mHDRBuffer->setGlareQuality(val); });

--- a/src/cs-core/GraphicsEngine.cpp
+++ b/src/cs-core/GraphicsEngine.cpp
@@ -188,7 +188,8 @@ GraphicsEngine::GraphicsEngine(std::shared_ptr<core::Settings> settings)
       toneMappingGLNode, static_cast<int>(utils::DrawOrder::eToneMapping));
 
   mSettings->mGraphics.pGlareIntensity.connectAndTouch(
-      [this](float val) { mToneMappingNode->setGlareIntensity(val); });
+      [this](float val) { mToneMappingNode->setGlareIntensity(val);
+                          mHDRBuffer->setGlareQuality(val);});
 
   mSettings->mGraphics.pGlareQuality.connectAndTouch(
       [this](uint32_t val) { mHDRBuffer->setGlareQuality(val); });

--- a/src/cs-graphics/CMakeLists.txt
+++ b/src/cs-graphics/CMakeLists.txt
@@ -12,9 +12,16 @@ file(GLOB SOURCE_FILES *.cpp */*.cpp)
 # Header files are only added in order to make them available in your IDE.
 file(GLOB HEADER_FILES *.hpp */*.hpp)
 
+# Shader files are also only added in order to make them available in your IDE.
+set(RESOURCE_SHADER_DIR ${CMAKE_SOURCE_DIR}/resources/shaders/)
+file(GLOB SHADER_FILES ${RESOURCE_SHADER_DIR}* ${RESOURCE_SHADER_DIR}*/*)
+
+source_group("src/shaders" FILES ${SHADER_FILES})
+
 add_library(cs-graphics SHARED
   ${SOURCE_FILES}
   ${HEADER_FILES}
+  ${SHADER_FILES}
 )
 
 target_link_libraries(cs-graphics

--- a/src/cs-graphics/GlareMipMap.cpp
+++ b/src/cs-graphics/GlareMipMap.cpp
@@ -204,7 +204,7 @@ void GlareMipMap::update(
   glMemoryBarrier(GL_SHADER_IMAGE_ACCESS_BARRIER_BIT);
 
   glUseProgram(mCompositeProgram);
-  // glBindImageTexture(1, mTemporaryTarget->GetId(), 0, GL_FALSE, 0, GL_READ_ONLY, GL_RGBA32F);
+  this->Bind(GL_TEXTURE0);
   glBindImageTexture(2, this->GetId(), 0, GL_FALSE, 0, GL_WRITE_ONLY, GL_RGBA32F);
   glDispatchCompute(static_cast<uint32_t>(std::ceil(0.5 * mHDRBufferWidth / 16)),
       static_cast<uint32_t>(std::ceil(0.5 * mHDRBufferHeight / 16)), 1);

--- a/src/cs-graphics/GlareMipMap.cpp
+++ b/src/cs-graphics/GlareMipMap.cpp
@@ -106,7 +106,7 @@ void GlareMipMap::update(
 
   utils::FrameStats::ScopedTimer timer("Compute Glare");
 
-  if (mGlareProgram == 0 || glareMode != mLastGlareMode || glareQuality != mLastGlareQuality) {
+  if (mGlareProgram == 0 || glareMode != mLastGlareMode || glareQuality != mLastGlareQuality || glareIntensity != mLastGlareIntensity) {
 
     // Create the compute shader.
     std::string source = "#version 430\n";

--- a/src/cs-graphics/GlareMipMap.hpp
+++ b/src/cs-graphics/GlareMipMap.hpp
@@ -32,7 +32,7 @@ class CS_GRAPHICS_EXPORT GlareMipMap : public VistaTexture {
   /// Perform the glare calculation by parallel reduction of the HDR values. This is a costly
   /// operation and should only be called once a frame.
   void update(
-      VistaTexture* hdrBufferComposite, HDRBuffer::GlareMode glareMode, uint32_t glareQuality);
+      VistaTexture* hdrBufferComposite, HDRBuffer::GlareMode glareMode, uint32_t glareQuality, float glareIntensity);
 
  private:
   GLuint               mGlareProgram     = 0;
@@ -43,6 +43,7 @@ class CS_GRAPHICS_EXPORT GlareMipMap : public VistaTexture {
   int                  mHDRBufferHeight  = 0;
   HDRBuffer::GlareMode mLastGlareMode    = HDRBuffer::GlareMode::eSymmetricGauss;
   uint32_t             mLastGlareQuality = 0;
+  float                mLastGlareIntensity = 0;
 
   struct {
     uint32_t level                   = 0;

--- a/src/cs-graphics/HDRBuffer.cpp
+++ b/src/cs-graphics/HDRBuffer.cpp
@@ -262,7 +262,7 @@ void HDRBuffer::updateGlareMipMap() {
     composite = hdrBuffer.mColorAttachments.at(1).get();
   }
 
-  hdrBuffer.mGlareMipMap->update(composite, mGlareMode, mGlareQuality);
+  hdrBuffer.mGlareMipMap->update(composite, mGlareMode, mGlareQuality, mGlareIntensity);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -294,6 +294,18 @@ void HDRBuffer::setGlareQuality(uint32_t quality) {
 
 uint32_t HDRBuffer::getGlareQuality() const {
   return mGlareQuality;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+void HDRBuffer::setGlareIntensity(float intensity) {
+  mGlareIntensity = intensity;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+float HDRBuffer::getGlareIntensity() const {
+  return mGlareIntensity;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/cs-graphics/HDRBuffer.hpp
+++ b/src/cs-graphics/HDRBuffer.hpp
@@ -90,6 +90,11 @@ class CS_GRAPHICS_EXPORT HDRBuffer {
   void     setGlareQuality(uint32_t quality);
   uint32_t getGlareQuality() const;
 
+  /// Controls the amount of artificial glare. Should be in the range [0-1]. If set to zero, the
+  /// GlareMipMap will not be updated which will increase performance.
+  void     setGlareIntensity(float intensity);
+  float    getGlareIntensity() const;
+
   /// Returns the depth attachment for the currently rendered viewport. Be aware, that this can be
   /// texture with the target GL_TEXTURE_2D_MULTISAMPLE if getMultiSamples() > 0.
   VistaTexture* getDepthAttachment() const;
@@ -133,6 +138,7 @@ class CS_GRAPHICS_EXPORT HDRBuffer {
 
   GlareMode                                         mGlareMode    = GlareMode::eSymmetricGauss;
   uint32_t                                          mGlareQuality = 0;
+  float                                             mGlareIntensity = 0.F;
   std::unordered_map<VistaViewport*, HDRBufferData> mHDRBufferData;
   float                                             mTotalLuminance   = 1.F;
   float                                             mMaximumLuminance = 1.F;


### PR DESCRIPTION
This pull request implements a compute-shader-based bi-cubic glare-interpolation as a preprocessing step. Previously, the bi-cubic glare-interpolation was performed on-the-fly in the tonemapping pass which operates at window resolution granularity, although the glare-MipMaps are by default not computed at full resolution.

As a result of this pull-request, the combined processing time for computing glare-MipMap computation and Tonemapping pass in bi-cubic interpolation mode is reduced drastically (as an example: from ~1.3 ms down to ~0.7 ms using default Cosmoscout-VR settings on a Laptop equipped with an NVIDIA RTX 3070).

The first image shows an example of the old in-place bi-cubic interpolation performed **within the tonemapping pass**. The GPU execution time of the tonemapping pass (larg green bar in GPU timing overview) is much higher than the preprocessing time of the glare maps (violet bar below the green bar), which creates the data being consumed by the tonemapping pass consumes.
![image](https://github.com/user-attachments/assets/306e8c5c-6081-463e-b128-4d4ca2d76f5c)


The second image shows an example of the new bi-cubic interpolation pre-processing approach, which reduces the tonemapping pass time drastically, while only slightly increasing the glare-map-computation time.
![image](https://github.com/user-attachments/assets/bf9fd7be-1470-424b-943a-8388937e01c3)

Future Work:
The compute-shader implementation is not optimal yet, since every thread in a compute-shader workgroup currently performs 16 independent texture lookups, despite high correlation between neighboring threads in a 2D pixel region. Follow-up work should investigate the effective use of shared memory in this scenario. First local implementation steps and tests indicate that the use of shared memory can reduce the combined run-time by another ~30%.
