### PR TITLE
🔧restore interactive window size and Gui state after taking Web-API c…

### DIFF
--- a/plugins/csp-web-api/src/Plugin.hpp
+++ b/plugins/csp-web-api/src/Plugin.hpp
@@ -61,6 +61,9 @@ class Plugin : public cs::core::PluginBase {
   int32_t                 mCaptureHeight    = 0;
   int32_t                 mCaptureDelay     = 0;
   std::string             mCaptureGui       = "auto";
+  bool                    mRestoreGui       = true;
+  int32_t                 mRestoreW         = -1;
+  int32_t                 mRestoreH         = -1;
   bool                    mCaptureDepth     = false;
   std::string             mCaptureFormat;
   int32_t                 mCaptureAtFrame = 0;

--- a/plugins/csp-web-api/src/Plugin.hpp
+++ b/plugins/csp-web-api/src/Plugin.hpp
@@ -61,6 +61,7 @@ class Plugin : public cs::core::PluginBase {
   int32_t                 mCaptureHeight    = 0;
   int32_t                 mCaptureDelay     = 0;
   std::string             mCaptureGui       = "auto";
+  bool                    mRestoreState     = false;
   bool                    mRestoreGui       = true;
   int32_t                 mRestoreW         = -1;
   int32_t                 mRestoreH         = -1;


### PR DESCRIPTION
Extend the state of the Web-API plugin with variables for remembering the window size and Gui activation state before changes were made for a capture. Restore window size and Gui activation after taking a capture. Tested on Windows.
Implements Feature Request #393 