### PR TITLE
🪲 remove the line through the pacific

### DIFF
--- a/plugins/csp-atmospheres/shaders/csp-atmosphere.frag
+++ b/plugins/csp-atmospheres/shaders/csp-atmosphere.frag
@@ -230,26 +230,7 @@ vec2 intersectOceansphere(vec3 rayOrigin, vec3 rayDir) {
 // centered at the origin.
 vec2 getLngLat(vec3 position) {
   vec2 result;
-
-  if (position.z != 0.0) {
-    result.x = atan(position.x / position.z);
-
-    if (position.z < 0 && position.x < 0) {
-      result.x -= PI;
-    }
-
-    if (position.z < 0 && position.x >= 0) {
-      result.x += PI;
-    }
-
-  } else if (position.x == 0) {
-    result.x = 0.0;
-  } else if (position.x < 0) {
-    result.x = -PI * 0.5;
-  } else {
-    result.x = PI * 0.5;
-  }
-
+  result.x = atan(position.x, position.z);
   result.y = asin(position.y / length(position));
   return result;
 }

--- a/plugins/csp-atmospheres/src/Atmosphere.cpp
+++ b/plugins/csp-atmospheres/src/Atmosphere.cpp
@@ -135,6 +135,9 @@ void Atmosphere::configure(Plugin::Settings::Atmosphere const& settings) {
     if (mSettings.mCloudTexture != settings.mCloudTexture) {
       if (settings.mCloudTexture.has_value() && !settings.mCloudTexture.value().empty()) {
         mCloudTexture = cs::graphics::TextureLoader::loadFromFile(settings.mCloudTexture.value());
+        mCloudTexture->Bind();
+        glTexParameteri(mCloudTexture->GetTarget(), GL_TEXTURE_MAX_LOD, 5);
+        mCloudTexture->Unbind();
       } else {
         mCloudTexture.reset();
       }


### PR DESCRIPTION
Through the pacific ocean, there is a one-pixel wide line even if all GUI is disabled. The line only disappears when clouds are disabled.
![with line](https://github.com/user-attachments/assets/7f73d469-3202-4812-bac5-0f1cb6830756)
On closer inspection it appears there are not one, but 10 lines
![line closeup](https://github.com/user-attachments/assets/cacd4b20-0b0a-4de4-a9c0-8e30a2e77d8c)
It is an issue with the sampling of the cloud texture at the line where u=1 and u=0 meet, similar to https://stackoverflow.com/questions/38357970/opengl-texture-repeat-artifacts.
I implemented the suggested solution of forcing a lower MAX_LOD, I found empirically, that at a maximum MipMap level of 5, the glitch reliably does not appear anymore.
![no line](https://github.com/user-attachments/assets/1b1887e8-f043-4a8c-9fb6-2436ada155c4)
Before I figured this out, I debugged the cloud rendering. Is there a reason for using one-parameter atan(y_over_x) with logic for handling the different cases, instead of using two-parameter atan(y, x). I changed this to two-parameter atan and still got the same results, is there a reason I overlooked for using single-parameter atan?