### PR TITLE
Fix initial star magnitude limits

### DIFF
--- a/plugins/csp-stars/src/Plugin.cpp
+++ b/plugins/csp-stars/src/Plugin.cpp
@@ -98,10 +98,12 @@ void Plugin::init() {
       mStarsTransform.get(), static_cast<int>(cs::utils::DrawOrder::eStars));
 
   // Configure the stars node when a public property is changed.
-  mPluginSettings.mEnabled.connect([this](bool val) { mStarsNode->SetIsEnabled(val); });
-  mPluginSettings.mDrawMode.connect([this](Stars::DrawMode val) { mStars->setDrawMode(val); });
-  mPluginSettings.mSize.connect([this](float val) { mStars->setSolidAngle(val * 0.0001F); });
-  mPluginSettings.mMagnitudeRange.connect([this](glm::vec2 const& val) {
+  mPluginSettings.mEnabled.connectAndTouch([this](bool val) { mStarsNode->SetIsEnabled(val); });
+  mPluginSettings.mDrawMode.connectAndTouch(
+      [this](Stars::DrawMode val) { mStars->setDrawMode(val); });
+  mPluginSettings.mSize.connectAndTouch(
+      [this](float val) { mStars->setSolidAngle(val * 0.0001F); });
+  mPluginSettings.mMagnitudeRange.connectAndTouch([this](glm::vec2 const& val) {
     mStars->setMinMagnitude(val.x);
     mStars->setMaxMagnitude(val.y);
   });

--- a/plugins/csp-stars/src/Plugin.hpp
+++ b/plugins/csp-stars/src/Plugin.hpp
@@ -40,7 +40,7 @@ class Plugin : public cs::core::PluginBase {
     cs::utils::DefaultProperty<float>           mLuminanceMultiplicator{0.F};
     cs::utils::DefaultProperty<Stars::DrawMode> mDrawMode{Stars::DrawMode::eSRPoint};
     cs::utils::DefaultProperty<float>           mSize{0.05F};
-    cs::utils::DefaultProperty<glm::vec2>       mMagnitudeRange{glm::vec2(-5.F, 13.F)};
+    cs::utils::DefaultProperty<glm::vec2>       mMagnitudeRange{glm::vec2(-10.F, 13.F)};
   };
 
   void init() override;


### PR DESCRIPTION
This ensures that the set magnitude limits are actually used initially. Also, the lower magnitude limit is reduced so that bright stars are not culled close to the camera.