### PR TITLE
Fix horizon flickering

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,12 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # Changelog of CosmoScout VR
 
+## [unreleased]
+
+#### Bug Fixes
+
+- Fix an issue which caused some flickering above the horizon at nighttime if refraction was enabled and lighting was disabled.
+
 ## [v1.10.0](https://github.com/cosmoscout/cosmoscout-vr/releases)
 
 **Release Date:** 2025-01-27

--- a/plugins/csp-atmospheres/shaders/csp-atmosphere.frag
+++ b/plugins/csp-atmospheres/shaders/csp-atmosphere.frag
@@ -301,8 +301,8 @@ vec3 getRefractedFramebufferColor(vec3 rayOrigin, vec3 rayDir, out vec3 refracte
 
   // Also, we check the depth buffer to see if the point is occluded. If it is, we do not sample
   // the color buffer.
-  bool occluded = getFramebufferDepth(texcoords.xy) > 0.0001;
-
+  bool occluded = getFramebufferDepth(texcoords.xy) > 0.0;
+  
   if (inside && !occluded) {
     return getFramebufferColor(texcoords.xy);
   }


### PR DESCRIPTION
This fixes an issue which caused some flickering above the horizon at nighttime if refraction was enabled and lighting was disabled.

Before | After
--- | ---
![Screenshot from 2025-02-10 14-45-09](https://github.com/user-attachments/assets/49890955-f1e7-473f-8cf7-e075f2deceb2) | ![Screenshot from 2025-02-10 14-45-29](https://github.com/user-attachments/assets/0ee86e20-64af-42c1-9d90-8ceb589a907d)
