### PR TITLE
Faster gui uploads

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,10 @@ SPDX-License-Identifier: CC-BY-4.0
 
 ## [unreleased]
 
+#### Other Changes
+
+- Improved rendering performance on some systems by uploading GUI textures using a staging buffer instead of using persistently mapped buffers.
+
 #### Bug Fixes
 
 - Fix an issue which caused some flickering above the horizon at nighttime if refraction was enabled and lighting was disabled.

--- a/src/cs-core/GraphicsEngine.cpp
+++ b/src/cs-core/GraphicsEngine.cpp
@@ -40,28 +40,28 @@ void GLAPIENTRY MessageCallback(GLenum source, GLenum type, GLuint id, GLenum se
   // that isnt an error or perf. issue)
   if (settings->pLogLevelGL.get() <= spdlog::level::debug &&
       severity == GL_DEBUG_SEVERITY_NOTIFICATION) {
-    logger().debug("{}", message);
+    logger().debug("{} ({})", message, id);
     return;
   }
 
   // Print the following infos (OpenGL errors, shader compile errors, perf. warnings, shader
   // compilation warnings, depricated code, redundant state changes, undefined behaviour)
   if (settings->pLogLevelGL.get() <= spdlog::level::info && severity == GL_DEBUG_SEVERITY_LOW) {
-    logger().info("{}", message);
+    logger().info("{} ({})", message, id);
     return;
   }
 
   // Print the following infos (OpenGL errors, shader compile errors, perf. warnings, shader
   // compilation warnings, depricated code)
   if (settings->pLogLevelGL.get() <= spdlog::level::warn && severity == GL_DEBUG_SEVERITY_MEDIUM) {
-    logger().warn("{}", message);
+    logger().warn("{} ({})", message, id);
     return;
   }
 
   // Print the following infos (OpenGL errors, shader compile errors)
   if (settings->pLogLevelGL.get() <= spdlog::level::critical &&
       severity == GL_DEBUG_SEVERITY_HIGH) {
-    logger().error("{}", message);
+    logger().error("{} ({})", message, id);
   }
 }
 

--- a/src/cs-core/GraphicsEngine.cpp
+++ b/src/cs-core/GraphicsEngine.cpp
@@ -102,6 +102,10 @@ GraphicsEngine::GraphicsEngine(std::shared_ptr<core::Settings> settings)
   // Attach the debug callback to print the messages.
   glDebugMessageCallback(MessageCallback, static_cast<void*>(mSettings.get()));
 
+  // Ignore debug messages telling us buffers are moved in memory.
+  GLuint id = 131186;
+  glDebugMessageControl(0x8246, 0x8250, GL_DONT_CARE, 1, &id, GL_FALSE);
+
   // setup shadows ---------------------------------------------------------------------------------
 
   mShadowMap->setEnabled(false);

--- a/src/cs-core/GraphicsEngine.cpp
+++ b/src/cs-core/GraphicsEngine.cpp
@@ -40,28 +40,28 @@ void GLAPIENTRY MessageCallback(GLenum source, GLenum type, GLuint id, GLenum se
   // that isnt an error or perf. issue)
   if (settings->pLogLevelGL.get() <= spdlog::level::debug &&
       severity == GL_DEBUG_SEVERITY_NOTIFICATION) {
-    logger().debug("{} ({})", message, id);
+    logger().debug("{} (source=0x{:x} type=0x{:x} id=0x{:x})", message, source, type, id);
     return;
   }
 
   // Print the following infos (OpenGL errors, shader compile errors, perf. warnings, shader
   // compilation warnings, depricated code, redundant state changes, undefined behaviour)
   if (settings->pLogLevelGL.get() <= spdlog::level::info && severity == GL_DEBUG_SEVERITY_LOW) {
-    logger().info("{} ({})", message, id);
+    logger().info("{} (source=0x{:x} type=0x{:x} id=0x{:x})", message, source, type, id);
     return;
   }
 
   // Print the following infos (OpenGL errors, shader compile errors, perf. warnings, shader
   // compilation warnings, depricated code)
   if (settings->pLogLevelGL.get() <= spdlog::level::warn && severity == GL_DEBUG_SEVERITY_MEDIUM) {
-    logger().warn("{} ({})", message, id);
+    logger().warn("{} (source=0x{:x} type=0x{:x} id=0x{:x})", message, source, type, id);
     return;
   }
 
   // Print the following infos (OpenGL errors, shader compile errors)
   if (settings->pLogLevelGL.get() <= spdlog::level::critical &&
       severity == GL_DEBUG_SEVERITY_HIGH) {
-    logger().error("{} ({})", message, id);
+    logger().error("{} (source=0x{:x} type=0x{:x} id=0x{:x})", message, source, type, id);
   }
 }
 

--- a/src/cs-core/GraphicsEngine.cpp
+++ b/src/cs-core/GraphicsEngine.cpp
@@ -106,6 +106,10 @@ GraphicsEngine::GraphicsEngine(std::shared_ptr<core::Settings> settings)
   GLuint id = 131186;
   glDebugMessageControl(0x8246, 0x8250, GL_DONT_CARE, 1, &id, GL_FALSE);
 
+  // Ignore synchronized transfer warning.
+  id = 0x20052;
+  glDebugMessageControl(0x8246, 0x8250, GL_DONT_CARE, 1, &id, GL_FALSE);
+
   // setup shadows ---------------------------------------------------------------------------------
 
   mShadowMap->setEnabled(false);

--- a/src/cs-gui/GuiItem.cpp
+++ b/src/cs-gui/GuiItem.cpp
@@ -51,9 +51,12 @@ GuiItem::GuiItem(std::string const& url, bool allowLocalFileAccess)
   mBufferData = static_cast<uint8_t*>(glMapBufferRange(GL_TEXTURE_BUFFER, 0, bufferSize, flags));
 
   glGenTextures(1, &mTexture);
-
-  glBindTexture(GL_TEXTURE_BUFFER, mTexture);
-  glTexBuffer(GL_TEXTURE_BUFFER, GL_RGBA8, mTextureBuffer);
+  glBindTexture(GL_TEXTURE_2D, mTexture);
+  glTexStorage2D(GL_TEXTURE_2D, 1, GL_RGBA8, getWidth(), getHeight());
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
   glBindBuffer(GL_TEXTURE_BUFFER, 0);
   glBindTexture(GL_TEXTURE_BUFFER, 0);
@@ -232,8 +235,14 @@ uint8_t* GuiItem::updateTexture(DrawEvent const& event) {
     glBufferStorage(GL_TEXTURE_BUFFER, bufferSize, nullptr, flags);
     mBufferData = static_cast<uint8_t*>(glMapBufferRange(GL_TEXTURE_BUFFER, 0, bufferSize, flags));
 
-    glBindTexture(GL_TEXTURE_BUFFER, mTexture);
-    glTexBuffer(GL_TEXTURE_BUFFER, GL_RGBA8, mTextureBuffer);
+    glDeleteTextures(1, &mTexture);
+    glGenTextures(1, &mTexture);
+    glBindTexture(GL_TEXTURE_2D, mTexture);
+    glTexStorage2D(GL_TEXTURE_2D, 1, GL_RGBA8, event.mWidth, event.mHeight);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
     glBindBuffer(GL_TEXTURE_BUFFER, 0);
     glBindTexture(GL_TEXTURE_BUFFER, 0);
@@ -298,6 +307,14 @@ void GuiItem::updateSizes() {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 uint32_t GuiItem::getTexture() const {
+
+  // Copy the texture buffer to the texture.
+  glBindBuffer(GL_PIXEL_UNPACK_BUFFER, mTextureBuffer);
+  glBindTexture(GL_TEXTURE_2D, mTexture);
+  glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, getWidth(), getHeight(), GL_BGRA, GL_UNSIGNED_BYTE, 0);
+  glBindTexture(GL_TEXTURE_2D, 0);
+  glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
+
   return mTexture;
 }
 

--- a/src/cs-gui/GuiItem.cpp
+++ b/src/cs-gui/GuiItem.cpp
@@ -231,7 +231,7 @@ uint8_t* GuiItem::updateTexture(DrawEvent const& event) {
     glBindBuffer(GL_TEXTURE_BUFFER, mTextureBuffer);
 
     size_t     bufferSize{4 * sizeof(uint8_t) * event.mWidth * event.mHeight};
-    GLbitfield flags = GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_COHERENT_BIT;
+    GLbitfield flags = GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT;
     glBufferStorage(GL_TEXTURE_BUFFER, bufferSize, nullptr, flags);
     mBufferData = static_cast<uint8_t*>(glMapBufferRange(GL_TEXTURE_BUFFER, 0, bufferSize, flags));
 

--- a/src/cs-gui/GuiItem.cpp
+++ b/src/cs-gui/GuiItem.cpp
@@ -37,38 +37,35 @@ GuiItem::GuiItem(std::string const& url, bool allowLocalFileAccess)
     , mIsRelPositionY(true)
     , mIsRelOffsetX(true)
     , mIsRelOffsetY(true) {
-  setDrawCallback([this](DrawEvent const& event) { return updateTexture(event); });
+
+  setDrawCallback([this](DrawEvent const& event) {
+    mPBOsNeedUpload = mTexturePBOs.size();
+
+    if (event.mResized) {
+      mTextureSizeX = event.mWidth;
+      mTextureSizeY = event.mHeight;
+
+      recreateBuffers();
+    }
+
+    return mPixels.data();
+  });
 
   setRequestKeyboardFocusCallback(
       [this](bool requested) { mIsKeyboardInputElementFocused = requested; });
 
-  glGenBuffers(1, &mTextureBuffer);
-  glBindBuffer(GL_TEXTURE_BUFFER, mTextureBuffer);
-  size_t bufferSize{4 * sizeof(uint8_t) * getWidth() * getHeight()};
+  mTextureSizeX = getWidth();
+  mTextureSizeY = getHeight();
 
-  GLbitfield flags = GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_COHERENT_BIT;
-  glBufferStorage(GL_TEXTURE_BUFFER, bufferSize, nullptr, flags);
-  mBufferData = static_cast<uint8_t*>(glMapBufferRange(GL_TEXTURE_BUFFER, 0, bufferSize, flags));
-
-  glGenTextures(1, &mTexture);
-  glBindTexture(GL_TEXTURE_2D, mTexture);
-  glTexStorage2D(GL_TEXTURE_2D, 1, GL_RGBA8, getWidth(), getHeight());
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-
-  glBindBuffer(GL_TEXTURE_BUFFER, 0);
-  glBindTexture(GL_TEXTURE_BUFFER, 0);
+  recreateBuffers();
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 GuiItem::~GuiItem() {
-  glBindBuffer(GL_TEXTURE_BUFFER, mTextureBuffer);
-  glUnmapBuffer(GL_TEXTURE_BUFFER);
-  glDeleteBuffers(1, &mTextureBuffer);
+  glDeleteBuffers(2, &mTexturePBOs[0]);
   glDeleteTextures(1, &mTexture);
+
   // seems to be necessary as OnPaint can be called by some other thread even
   // if this object is already deleted
   setDrawCallback([](DrawEvent const& /*unused*/) { return nullptr; });
@@ -220,46 +217,68 @@ bool GuiItem::calculateMousePosition(int areaX, int areaY, int& x, int& y) {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-uint8_t* GuiItem::updateTexture(DrawEvent const& event) {
-  if (event.mResized) {
-    glBindBuffer(GL_TEXTURE_BUFFER, mTextureBuffer);
-    glUnmapBuffer(GL_TEXTURE_BUFFER);
-    glBindBuffer(GL_TEXTURE_BUFFER, 0);
-
-    glDeleteBuffers(1, &mTextureBuffer);
-    glGenBuffers(1, &mTextureBuffer);
-    glBindBuffer(GL_TEXTURE_BUFFER, mTextureBuffer);
-
-    size_t     bufferSize{4 * sizeof(uint8_t) * event.mWidth * event.mHeight};
-    GLbitfield flags = GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT;
-    glBufferStorage(GL_TEXTURE_BUFFER, bufferSize, nullptr, flags);
-    mBufferData = static_cast<uint8_t*>(glMapBufferRange(GL_TEXTURE_BUFFER, 0, bufferSize, flags));
-
-    glDeleteTextures(1, &mTexture);
-    glGenTextures(1, &mTexture);
-    glBindTexture(GL_TEXTURE_2D, mTexture);
-    glTexStorage2D(GL_TEXTURE_2D, 1, GL_RGBA8, event.mWidth, event.mHeight);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-
-    glBindBuffer(GL_TEXTURE_BUFFER, 0);
-    glBindTexture(GL_TEXTURE_BUFFER, 0);
-    mTextureSizeX = event.mWidth;
-    mTextureSizeY = event.mHeight;
-  }
-
-  return mBufferData;
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
 void GuiItem::onAreaResize(int width, int height) {
   mAreaWidth  = width;
   mAreaHeight = height;
 
   updateSizes();
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+uint32_t GuiItem::getTexture() const {
+
+  // Copy the pixels buffer to the texture.
+  if (mPBOsNeedUpload > 0) {
+
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, mTexturePBOs[mCurrentPBO]);
+    auto ptr = static_cast<uint8_t*>(glMapBufferRange(
+        GL_PIXEL_UNPACK_BUFFER, 0, 4 * mTextureSizeX * mTextureSizeY, GL_MAP_WRITE_BIT));
+    std::memcpy(ptr, mPixels.data(), 4 * mTextureSizeX * mTextureSizeY);
+    glUnmapBuffer(GL_PIXEL_UNPACK_BUFFER);
+
+    glBindTexture(GL_TEXTURE_2D, mTexture);
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER,
+        mTexturePBOs[(mCurrentPBO + mTexturePBOs.size() - 1) % mTexturePBOs.size()]);
+    glTexSubImage2D(
+        GL_TEXTURE_2D, 0, 0, 0, mTextureSizeX, mTextureSizeY, GL_BGRA, GL_UNSIGNED_BYTE, 0);
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
+    glBindTexture(GL_TEXTURE_2D, 0);
+
+    mCurrentPBO = (mCurrentPBO + 1) % mTexturePBOs.size();
+    mPBOsNeedUpload -= 1;
+  }
+
+  return mTexture;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+void GuiItem::recreateBuffers() {
+
+  if (mTexture) {
+    glDeleteTextures(1, &mTexture);
+    glDeleteBuffers(2, &mTexturePBOs[0]);
+  }
+
+  for (size_t i = 0; i < mTexturePBOs.size(); ++i) {
+    glGenBuffers(1, &mTexturePBOs[i]);
+    glBindBuffer(GL_TEXTURE_BUFFER, mTexturePBOs[i]);
+    glBufferStorage(
+        GL_TEXTURE_BUFFER, 4 * mTextureSizeX * mTextureSizeY, nullptr, GL_MAP_WRITE_BIT);
+  }
+  glBindBuffer(GL_TEXTURE_BUFFER, 0);
+
+  glGenTextures(1, &mTexture);
+  glBindTexture(GL_TEXTURE_2D, mTexture);
+  glTexStorage2D(GL_TEXTURE_2D, 1, GL_RGBA8, mTextureSizeX, mTextureSizeY);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  glBindTexture(GL_TEXTURE_2D, 0);
+
+  mPixels.resize(4 * mTextureSizeX * mTextureSizeY);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -302,20 +321,6 @@ void GuiItem::updateSizes() {
   }
 
   resize(static_cast<int>(mSizeX), static_cast<int>(mSizeY));
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-uint32_t GuiItem::getTexture() const {
-
-  // Copy the texture buffer to the texture.
-  glBindBuffer(GL_PIXEL_UNPACK_BUFFER, mTextureBuffer);
-  glBindTexture(GL_TEXTURE_2D, mTexture);
-  glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, getWidth(), getHeight(), GL_BGRA, GL_UNSIGNED_BYTE, 0);
-  glBindTexture(GL_TEXTURE_2D, 0);
-  glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
-
-  return mTexture;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/cs-gui/GuiItem.cpp
+++ b/src/cs-gui/GuiItem.cpp
@@ -39,7 +39,7 @@ GuiItem::GuiItem(std::string const& url, bool allowLocalFileAccess)
     , mIsRelOffsetY(true) {
 
   setDrawCallback([this](DrawEvent const& event) {
-    mPBOsNeedUpload = mTexturePBOs.size();
+    mPBOsNeedUpload = static_cast<uint8_t>(mTexturePBOs.size());
 
     if (event.mResized) {
       mTextureSizeX = event.mWidth;

--- a/src/cs-gui/GuiItem.hpp
+++ b/src/cs-gui/GuiItem.hpp
@@ -10,6 +10,8 @@
 
 #include "WebView.hpp"
 
+#include <array>
+
 class VistaTexture;
 
 namespace cs::gui {

--- a/src/cs-gui/GuiItem.hpp
+++ b/src/cs-gui/GuiItem.hpp
@@ -86,12 +86,14 @@ class CS_GUI_EXPORT GuiItem : public WebView {
   uint32_t getTexture() const;
 
  private:
-  uint8_t* updateTexture(DrawEvent const& event);
-  void     updateSizes();
+  void recreateBuffers();
+  void updateSizes();
 
-  uint32_t mTextureBuffer{};
-  uint32_t mTexture{};
-  uint8_t* mBufferData = nullptr;
+  std::vector<uint8_t>    mPixels;
+  uint32_t                mTexture = 0;
+  std::array<uint32_t, 2> mTexturePBOs;
+  mutable uint8_t         mCurrentPBO     = 0;
+  mutable uint8_t         mPBOsNeedUpload = 0;
 
   // in pixels
   int mTextureSizeX = 0;

--- a/src/cs-gui/ScreenSpaceGuiArea.cpp
+++ b/src/cs-gui/ScreenSpaceGuiArea.cpp
@@ -52,18 +52,13 @@ const char* const ScreenSpaceGuiArea::QUAD_FRAG = R"(
 in vec2 vTexCoords;
 in vec4 vPosition;
 
-uniform samplerBuffer texture;
+uniform sampler2D texture;
 uniform ivec2 texSize;
 
 layout(location = 0) out vec4 vOutColor;
 
-vec4 getTexel(ivec2 p) {
-  p = clamp(p, ivec2(0), texSize - ivec2(1));
-  return texelFetch(texture, p.y * texSize.x + p.x).bgra;
-}
-
 void main() {
-  vOutColor = getTexel(ivec2(vec2(texSize) * vTexCoords));
+  vOutColor = texelFetch(texture, ivec2(texSize * vTexCoords), 0);
   if (vOutColor.a == 0.0) discard;
   vOutColor.rgb /= vOutColor.a;
 }
@@ -139,12 +134,12 @@ bool ScreenSpaceGuiArea::Do() {
       glUniform2i(mUniforms.texSize, guiItem->getTextureSizeX(), guiItem->getTextureSizeY());
 
       glActiveTexture(GL_TEXTURE0);
-      glBindTexture(GL_TEXTURE_BUFFER, guiItem->getTexture());
+      glBindTexture(GL_TEXTURE_2D, guiItem->getTexture());
       mShader.SetUniform(mUniforms.texture, 0);
 
       glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 
-      glBindTexture(GL_TEXTURE_BUFFER, 0);
+      glBindTexture(GL_TEXTURE_2D, 0);
     }
   }
 

--- a/src/cs-gui/WorldSpaceGuiArea.cpp
+++ b/src/cs-gui/WorldSpaceGuiArea.cpp
@@ -55,7 +55,6 @@ const char* const WorldSpaceGuiArea::QUAD_FRAG = R"(
 in vec2 vTexCoords;
 
 uniform sampler2D texture;
-uniform ivec2 texSize;
 
 layout(location = 0) out vec4 vOutColor;
 
@@ -164,7 +163,6 @@ bool WorldSpaceGuiArea::Do() {
 
     mUniforms.projectionMatrix = mShader.GetUniformLocation("uMatProjection");
     mUniforms.modelViewMatrix  = mShader.GetUniformLocation("uMatModelView");
-    mUniforms.texSize          = mShader.GetUniformLocation("texSize");
     mUniforms.texture          = mShader.GetUniformLocation("texture");
 
     mShaderDirty = false;
@@ -214,8 +212,6 @@ bool WorldSpaceGuiArea::Do() {
           glm::scale(localMat, glm::vec3(guiItem->getRelSizeX(), guiItem->getRelSizeY(), 1.F));
 
       glUniformMatrix4fv(mUniforms.modelViewMatrix, 1, GL_FALSE, glm::value_ptr(localMat));
-
-      glUniform2i(mUniforms.texSize, guiItem->getTextureSizeX(), guiItem->getTextureSizeY());
 
       glActiveTexture(GL_TEXTURE0);
       glBindTexture(GL_TEXTURE_2D, guiItem->getTexture());

--- a/src/cs-gui/WorldSpaceGuiArea.cpp
+++ b/src/cs-gui/WorldSpaceGuiArea.cpp
@@ -54,35 +54,17 @@ void main()
 const char* const WorldSpaceGuiArea::QUAD_FRAG = R"(
 in vec2 vTexCoords;
 
-uniform samplerBuffer texture;
+uniform sampler2D texture;
 uniform ivec2 texSize;
 
 layout(location = 0) out vec4 vOutColor;
 
 vec4 getTexel(ivec2 p) {
-  p = clamp(p, ivec2(0), texSize - ivec2(1));
-  return texelFetch(texture, p.y * texSize.x + p.x).bgra;
-}
-
-vec4 getPixel(vec2 position) {
-  vec2 absolutePosition = position * texSize - 0.5;
-  ivec2 iPosition = ivec2(absolutePosition);
-
-  vec4 tl = getTexel(iPosition);
-  vec4 tr = getTexel(iPosition + ivec2(1, 0));
-  vec4 bl = getTexel(iPosition + ivec2(0, 1));
-  vec4 br = getTexel(iPosition + ivec2(1, 1));
-
-  vec2 d = fract(absolutePosition);
-
-  vec4 top = mix(tl, tr, d.x);
-  vec4 bot = mix(bl, br, d.x);
-
-  return mix(top, bot, d.y);
+  return texelFetch(texture, p, 0).bgra;
 }
 
 void main() {
-  vOutColor = getPixel(vTexCoords);
+  vOutColor = texture2D(texture, vTexCoords);
   if (vOutColor.a == 0.0) discard;
 
   vOutColor.rgb /= vOutColor.a;
@@ -236,12 +218,12 @@ bool WorldSpaceGuiArea::Do() {
       glUniform2i(mUniforms.texSize, guiItem->getTextureSizeX(), guiItem->getTextureSizeY());
 
       glActiveTexture(GL_TEXTURE0);
-      glBindTexture(GL_TEXTURE_BUFFER, guiItem->getTexture());
+      glBindTexture(GL_TEXTURE_2D, guiItem->getTexture());
       mShader.SetUniform(mUniforms.texture, 0);
 
       glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 
-      glBindTexture(GL_TEXTURE_BUFFER, 0);
+      glBindTexture(GL_TEXTURE_2D, 0);
     }
   }
 


### PR DESCRIPTION
This improves rendering performance on some systems by uploading GUI textures using a staging buffer instead of using persistently mapped buffers.