### PR TITLE
Less depth buffer copies

### DIFF
--- a/plugins/csp-atmospheres/src/Atmosphere.cpp
+++ b/plugins/csp-atmospheres/src/Atmosphere.cpp
@@ -375,8 +375,10 @@ bool Atmosphere::Do() {
     mHDRBuffer->bind();
   }
 
-  mGraphicsEngine->bindCurrentDepthBufferAsTexture(GL_TEXTURE0, false);
-  mGraphicsEngine->bindCurrentColorBufferAsTexture(GL_TEXTURE1, false);
+  auto depthBuffer = mGraphicsEngine->getCurrentDepthBufferAsTexture(false);
+  auto colorBuffer = mGraphicsEngine->getCurrentColorBufferAsTexture(false);
+  depthBuffer->Bind(GL_TEXTURE0);
+  colorBuffer->Bind(GL_TEXTURE1);
 
   mAtmoShader.SetUniform(mAtmoUniforms.depthBuffer, 0);
   mAtmoShader.SetUniform(mAtmoUniforms.colorBuffer, 1);
@@ -423,10 +425,8 @@ bool Atmosphere::Do() {
   // Reset eclipse shadow-related texture units.
   mEclipseShadowReceiver->postRender();
 
-  glActiveTexture(GL_TEXTURE0);
-  glBindTexture(GL_TEXTURE_2D, 0);
-  glActiveTexture(GL_TEXTURE1);
-  glBindTexture(GL_TEXTURE_2D, 0);
+  depthBuffer->Unbind(GL_TEXTURE0);
+  colorBuffer->Unbind(GL_TEXTURE1);
 
   if (mSettings.mEnableClouds.get() && mCloudTexture) {
     mCloudTexture->Unbind(GL_TEXTURE2);

--- a/plugins/csp-atmospheres/src/Atmosphere.hpp
+++ b/plugins/csp-atmospheres/src/Atmosphere.hpp
@@ -99,13 +99,6 @@ class Atmosphere : public IVistaOpenGLDraw {
 
   int mEnableHDRConnection = -1;
 
-  struct GBufferData {
-    std::unique_ptr<VistaTexture> mDepthBuffer;
-    std::unique_ptr<VistaTexture> mColorBuffer;
-  };
-
-  std::unordered_map<VistaViewport*, GBufferData> mGBufferData;
-
   bool       mShaderDirty    = true;
   double     mSunIlluminance = 1.0;
   double     mSunLuminance   = 1.0;

--- a/plugins/csp-sharad/src/Plugin.cpp
+++ b/plugins/csp-sharad/src/Plugin.cpp
@@ -91,9 +91,9 @@ void Plugin::init() {
 
           if (ext == ".tab") {
             std::string sName = file.substr(0, file.length() - 5);
-            auto        sharad =
-                std::make_shared<Sharad>(mAllSettings, mSolarSystem, mPluginSettings.mAnchor,
-                    filePath + sName + "_tiff.tif", filePath + sName + "_geom.tab");
+            auto sharad = std::make_shared<Sharad>(mAllSettings, mGraphicsEngine, mSolarSystem,
+                mPluginSettings.mAnchor, filePath + sName + "_tiff.tif",
+                filePath + sName + "_geom.tab");
 
             auto* sharadNode = mSceneGraph->NewOpenGLNode(mSceneGraph->GetRoot(), sharad.get());
             VistaOpenSGMaterialTools::SetSortKeyOnSubtree(

--- a/plugins/csp-sharad/src/Sharad.cpp
+++ b/plugins/csp-sharad/src/Sharad.cpp
@@ -301,15 +301,14 @@ bool Sharad::Do() {
     mShader.SetUniform(mUniforms.time, static_cast<float>(mCurrTime - mStartTime));
 
     mTexture->Bind(GL_TEXTURE0);
-    mGraphicsEngine->bindCurrentDepthBufferAsTexture(GL_TEXTURE1, false);
+    auto depthBuffer = mGraphicsEngine->getCurrentDepthBufferAsTexture(false);
+    depthBuffer->Bind(GL_TEXTURE1);
 
     glPushAttrib(GL_ENABLE_BIT | GL_DEPTH_BUFFER_BIT);
 
     glEnable(GL_BLEND);
     glDisable(GL_CULL_FACE);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    // glDepthFunc(GL_GEQUAL);
-    // glDepthMask(false);
     glDisable(GL_DEPTH_TEST);
 
     // draw --------------------------------------------------------------------
@@ -320,6 +319,7 @@ bool Sharad::Do() {
     // clean up ----------------------------------------------------------------
     glEnable(GL_CULL_FACE);
     mTexture->Unbind(GL_TEXTURE0);
+    depthBuffer->Unbind(GL_TEXTURE1);
 
     glPopAttrib();
 

--- a/plugins/csp-sharad/src/Sharad.cpp
+++ b/plugins/csp-sharad/src/Sharad.cpp
@@ -77,7 +77,7 @@ const char* Sharad::FRAG = R"(
 #version 330
 
 uniform mat4 uMatProjection;
-uniform sampler2DRect uDepthBuffer;
+uniform sampler2D uDepthBuffer;
 uniform sampler2D uSharadTexture;
 uniform float uAmbientBrightness;
 uniform float uTime;
@@ -100,7 +100,7 @@ void main()
         discard;
     }
 
-    float fDepth = texture(uDepthBuffer,  gl_FragCoord.xy - uViewportPos).r;
+    float fDepth = texture(uDepthBuffer, gl_FragCoord.xy / textureSize(uDepthBuffer, 0)).r;
     vec4 surfacePos = inverse(uMatProjection) * vec4(vPositionSS.xy / vPositionSS.w, 2*fDepth-1, 1);
     float surfaceDistance = length(surfacePos.xyz / surfacePos.w);
     float sharadDistance  = length(vPositionVS);
@@ -159,7 +159,7 @@ Sharad::Sharad(std::shared_ptr<cs::core::Settings> settings,
     , mObjectName(std::move(objectName)) {
 
   if (mInstanceCount == 0) {
-    mDepthBuffer = std::make_unique<VistaTexture>(GL_TEXTURE_RECTANGLE);
+    mDepthBuffer = std::make_unique<VistaTexture>(GL_TEXTURE_2D);
     mDepthBuffer->Bind();
     mDepthBuffer->SetWrapS(GL_CLAMP);
     mDepthBuffer->SetWrapT(GL_CLAMP);
@@ -388,7 +388,7 @@ bool Sharad::FramebufferCallback::Do() {
   std::array<GLint, 4> iViewport{};
   glGetIntegerv(GL_VIEWPORT, iViewport.data());
   mDepthBuffer->Bind();
-  glCopyTexImage2D(GL_TEXTURE_RECTANGLE, 0, GL_DEPTH_COMPONENT, iViewport.at(0), iViewport.at(1),
+  glCopyTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT, iViewport.at(0), iViewport.at(1),
       iViewport.at(2), iViewport.at(3), 0);
   return true;
 }

--- a/plugins/csp-sharad/src/Sharad.cpp
+++ b/plugins/csp-sharad/src/Sharad.cpp
@@ -100,7 +100,7 @@ void main()
         discard;
     }
 
-    float fDepth = texture(uDepthBuffer, gl_FragCoord.xy / textureSize(uDepthBuffer, 0)).r;
+    float fDepth = texture(uDepthBuffer, (gl_FragCoord.xy - uViewportPos) / textureSize(uDepthBuffer, 0)).r;
     vec4 surfacePos = inverse(uMatProjection) * vec4(vPositionSS.xy / vPositionSS.w, 2*fDepth-1, 1);
     float surfaceDistance = length(surfacePos.xyz / surfacePos.w);
     float sharadDistance  = length(vPositionVS);
@@ -119,13 +119,6 @@ void main()
     oColor.a = 1.0 - clamp((sharadDistance - surfaceDistance) * uSceneScale / 30000, 0.1, 1.0);
 }
 )";
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-std::unique_ptr<VistaTexture>                Sharad::mDepthBuffer     = nullptr;
-std::unique_ptr<Sharad::FramebufferCallback> Sharad::mPreCallback     = nullptr;
-std::unique_ptr<VistaOpenGLNode>             Sharad::mPreCallbackNode = nullptr;
-int                                          Sharad::mInstanceCount   = 0;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -151,33 +144,14 @@ struct ProfileRadarData {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 Sharad::Sharad(std::shared_ptr<cs::core::Settings> settings,
+    std::shared_ptr<cs::core::GraphicsEngine>      graphicsEngine,
     std::shared_ptr<cs::core::SolarSystem> solarSystem, std::string objectName,
     std::string const& sTiffFile, std::string const& sTabFile)
     : mSettings(std::move(settings))
+    , mGraphicsEngine(std::move(graphicsEngine))
     , mSolarSystem(std::move(solarSystem))
     , mTexture(cs::graphics::TextureLoader::loadFromFile(sTiffFile))
     , mObjectName(std::move(objectName)) {
-
-  if (mInstanceCount == 0) {
-    mDepthBuffer = std::make_unique<VistaTexture>(GL_TEXTURE_2D);
-    mDepthBuffer->Bind();
-    mDepthBuffer->SetWrapS(GL_CLAMP);
-    mDepthBuffer->SetWrapT(GL_CLAMP);
-    mDepthBuffer->SetMinFilter(GL_NEAREST);
-    mDepthBuffer->SetMagFilter(GL_NEAREST);
-    mDepthBuffer->Unbind();
-
-    mPreCallback = std::make_unique<FramebufferCallback>(mDepthBuffer.get());
-
-    auto* sceneGraph = GetVistaSystem()->GetGraphicsManager()->GetSceneGraph();
-    mPreCallbackNode = std::unique_ptr<VistaOpenGLNode>(
-        sceneGraph->NewOpenGLNode(sceneGraph->GetRoot(), mPreCallback.get()));
-
-    VistaOpenSGMaterialTools::SetSortKeyOnSubtree(
-        mPreCallbackNode.get(), static_cast<int>(cs::utils::DrawOrder::eOpaqueNonHDR) + 1);
-  }
-
-  ++mInstanceCount;
 
   // Disables a warning in MSVC about using fopen_s and fscanf_s, which aren't supported in GCC.
   CS_WARNINGS_PUSH
@@ -280,21 +254,6 @@ Sharad::Sharad(std::shared_ptr<cs::core::Settings> settings,
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-Sharad::~Sharad() {
-  --mInstanceCount;
-
-  if (mInstanceCount == 0) {
-    auto* sceneGraph = GetVistaSystem()->GetGraphicsManager()->GetSceneGraph();
-    sceneGraph->GetRoot()->DisconnectChild(mPreCallbackNode.get());
-
-    mPreCallback.reset(nullptr);
-    mDepthBuffer.reset(nullptr);
-    mPreCallbackNode.reset(nullptr);
-  }
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
 double Sharad::getStartTime() const {
   return mStartTime;
 }
@@ -342,7 +301,7 @@ bool Sharad::Do() {
     mShader.SetUniform(mUniforms.time, static_cast<float>(mCurrTime - mStartTime));
 
     mTexture->Bind(GL_TEXTURE0);
-    mDepthBuffer->Bind(GL_TEXTURE1);
+    mGraphicsEngine->bindCurrentDepthBufferAsTexture(GL_TEXTURE1, false);
 
     glPushAttrib(GL_ENABLE_BIT | GL_DEPTH_BUFFER_BIT);
 
@@ -374,23 +333,6 @@ bool Sharad::Do() {
 
 bool Sharad::GetBoundingBox(VistaBoundingBox& /*bb*/) {
   return false;
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-Sharad::FramebufferCallback::FramebufferCallback(VistaTexture* pDepthBuffer)
-    : mDepthBuffer(pDepthBuffer) {
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-bool Sharad::FramebufferCallback::Do() {
-  std::array<GLint, 4> iViewport{};
-  glGetIntegerv(GL_VIEWPORT, iViewport.data());
-  mDepthBuffer->Bind();
-  glCopyTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT, iViewport.at(0), iViewport.at(1),
-      iViewport.at(2), iViewport.at(3), 0);
-  return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/plugins/csp-sharad/src/Sharad.hpp
+++ b/plugins/csp-sharad/src/Sharad.hpp
@@ -8,6 +8,7 @@
 #ifndef CSP_SHARAD_HPP
 #define CSP_SHARAD_HPP
 
+#include "../../../src/cs-core/GraphicsEngine.hpp"
 #include "../../../src/cs-core/Settings.hpp"
 #include "../../../src/cs-core/SolarSystem.hpp"
 
@@ -26,7 +27,8 @@ namespace csp::sharad {
 /// Renders a single SHARAD image.
 class Sharad : public IVistaOpenGLDraw {
  public:
-  Sharad(std::shared_ptr<cs::core::Settings> settings,
+  Sharad(std::shared_ptr<cs::core::Settings>    settings,
+      std::shared_ptr<cs::core::GraphicsEngine> graphicsEngine,
       std::shared_ptr<cs::core::SolarSystem> solarSystem, std::string objectName,
       std::string const& sTiffFile, std::string const& sTabFile);
 
@@ -36,8 +38,6 @@ class Sharad : public IVistaOpenGLDraw {
   Sharad& operator=(Sharad const& other) = delete;
   Sharad& operator=(Sharad&& other)      = delete;
 
-  ~Sharad();
-
   double getStartTime() const;
 
   void update(double tTime, double sceneScale);
@@ -46,27 +46,10 @@ class Sharad : public IVistaOpenGLDraw {
   bool GetBoundingBox(VistaBoundingBox& bb) override;
 
  private:
-  class FramebufferCallback : public IVistaOpenGLDraw {
-   public:
-    explicit FramebufferCallback(VistaTexture* pDepthBuffer);
-
-    bool Do() override;
-    bool GetBoundingBox(VistaBoundingBox& /*bb*/) override {
-      return true;
-    }
-
-   private:
-    VistaTexture* mDepthBuffer;
-  };
-
-  static std::unique_ptr<VistaTexture>        mDepthBuffer;
-  static std::unique_ptr<FramebufferCallback> mPreCallback;
-  static std::unique_ptr<VistaOpenGLNode>     mPreCallbackNode;
-  static int                                  mInstanceCount;
-
-  std::shared_ptr<cs::core::Settings>    mSettings;
-  std::shared_ptr<cs::core::SolarSystem> mSolarSystem;
-  std::unique_ptr<VistaTexture>          mTexture;
+  std::shared_ptr<cs::core::Settings>       mSettings;
+  std::shared_ptr<cs::core::GraphicsEngine> mGraphicsEngine;
+  std::shared_ptr<cs::core::SolarSystem>    mSolarSystem;
+  std::unique_ptr<VistaTexture>             mTexture;
 
   std::string mObjectName;
   double      mStartTime;

--- a/plugins/csp-wms-overlays/src/Plugin.cpp
+++ b/plugins/csp-wms-overlays/src/Plugin.cpp
@@ -532,7 +532,7 @@ void Plugin::onLoad() {
     }
 
     auto wmsOverlay = std::make_shared<TextureOverlayRenderer>(
-        settings.first, mSolarSystem, mTimeControl, mAllSettings, mPluginSettings);
+        settings.first, mGraphicsEngine, mSolarSystem, mTimeControl, mAllSettings, mPluginSettings);
 
     mWMSOverlays.emplace(settings.first, wmsOverlay);
 

--- a/plugins/csp-wms-overlays/src/ShadersTextureOverlay.cpp
+++ b/plugins/csp-wms-overlays/src/ShadersTextureOverlay.cpp
@@ -52,23 +52,23 @@ const std::string TextureOverlayRenderer::SURFACE_VERT = R"(
 const std::string TextureOverlayRenderer::SURFACE_FRAG = R"(
     out vec4 FragColor;
 
-    uniform sampler2DRect uDepthBuffer;
-    uniform sampler2D     uFirstTexture;
-    uniform sampler2D     uSecondTexture;
+    uniform sampler2D uDepthBuffer;
+    uniform sampler2D uFirstTexture;
+    uniform sampler2D uSecondTexture;
 
-    uniform float         uFade;
-    uniform bool          uUseFirstTexture;
-    uniform bool          uUseSecondTexture;
+    uniform float     uFade;
+    uniform bool      uUseFirstTexture;
+    uniform bool      uUseSecondTexture;
 
-    uniform dmat4         uMatInvMVP;
+    uniform dmat4     uMatInvMVP;
 
-    uniform dvec2         uLonRange;
-    uniform dvec2         uLatRange;
-    uniform vec3          uRadii;
+    uniform dvec2     uLonRange;
+    uniform dvec2     uLatRange;
+    uniform vec3      uRadii;
 
-    uniform float         uAmbientBrightness;
-    uniform float         uSunIlluminance;
-    uniform vec3          uSunDirection;
+    uniform float     uAmbientBrightness;
+    uniform float     uSunIlluminance;
+    uniform vec3      uSunDirection;
 
     in vec2 texcoord;
 
@@ -104,8 +104,7 @@ const std::string TextureOverlayRenderer::SURFACE_FRAG = R"(
     // ===========================================================================
     void main()
     {
-        vec2  vTexcoords = texcoord*textureSize(uDepthBuffer);
-        float fDepth     = texture(uDepthBuffer, vTexcoords).r;
+        float fDepth = texture(uDepthBuffer, texcoord).r;
 
         if (fDepth == 1.0) 
         {

--- a/plugins/csp-wms-overlays/src/TextureOverlayRenderer.cpp
+++ b/plugins/csp-wms-overlays/src/TextureOverlayRenderer.cpp
@@ -10,6 +10,7 @@
 
 #include "logger.hpp"
 
+#include "../../../src/cs-core/GraphicsEngine.hpp"
 #include "../../../src/cs-core/Settings.hpp"
 #include "../../../src/cs-core/SolarSystem.hpp"
 #include "../../../src/cs-core/TimeControl.hpp"
@@ -44,10 +45,12 @@ namespace csp::wmsoverlays {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 TextureOverlayRenderer::TextureOverlayRenderer(std::string objectName,
+    std::shared_ptr<cs::core::GraphicsEngine>              graphicsEngine,
     std::shared_ptr<cs::core::SolarSystem>                 solarSystem,
     std::shared_ptr<cs::core::TimeControl>                 timeControl,
     std::shared_ptr<cs::core::Settings> settings, std::shared_ptr<Plugin::Settings> pluginSettings)
     : mSettings(std::move(settings))
+    , mGraphicsEngine(std::move(graphicsEngine))
     , mPluginSettings(std::move(pluginSettings))
     , mObjectName(std::move(objectName))
     , mWMSTexture(GL_TEXTURE_2D)
@@ -60,18 +63,6 @@ TextureOverlayRenderer::TextureOverlayRenderer(std::string objectName,
   mMaxBounds  = object->getRadii();
 
   // create textures ---------------------------------------------------------
-  for (auto const& viewport : GetVistaSystem()->GetDisplayManager()->GetViewports()) {
-    // Texture for previous renderer depth buffer
-    const auto [buffer, success] = mDepthBufferData.try_emplace(viewport.second, GL_TEXTURE_2D);
-    if (success) {
-      buffer->second.Bind();
-      buffer->second.SetWrapS(GL_CLAMP);
-      buffer->second.SetWrapT(GL_CLAMP);
-      buffer->second.SetMinFilter(GL_NEAREST);
-      buffer->second.SetMagFilter(GL_NEAREST);
-      buffer->second.Unbind();
-    }
-  }
 
   mWMSTexture.Bind();
   mWMSTexture.SetWrapS(GL_CLAMP_TO_EDGE);
@@ -532,17 +523,6 @@ bool TextureOverlayRenderer::Do() {
   glDepthMask(GL_FALSE);
   glEnable(GL_BLEND);
 
-  // copy depth buffer from previous rendering
-  std::array<GLint, 4> iViewport{};
-  glGetIntegerv(GL_VIEWPORT, iViewport.data());
-
-  auto* viewport = GetVistaSystem()->GetDisplayManager()->GetCurrentRenderInfo()->m_pViewport;
-  VistaTexture& depthBuffer = mDepthBufferData.at(viewport);
-
-  depthBuffer.Bind();
-  glCopyTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT, iViewport[0], iViewport[1], iViewport[2],
-      iViewport[3], 0);
-
   auto object    = mSolarSystem->getObject(mObjectName);
   auto radii     = object->getRadii();
   auto transform = object->getObserverRelativeTransform();
@@ -561,7 +541,7 @@ bool TextureOverlayRenderer::Do() {
   mShader.Bind();
 
   // Only bind the enabled textures.
-  depthBuffer.Bind(GL_TEXTURE0);
+  mGraphicsEngine->bindCurrentDepthBufferAsTexture(GL_TEXTURE0, false);
   if (mWMSTextureUsed) {
     mWMSTexture.Bind(GL_TEXTURE1);
 
@@ -631,7 +611,9 @@ bool TextureOverlayRenderer::Do() {
   // Dummy draw
   glDrawArrays(GL_POINTS, 0, 1);
 
-  depthBuffer.Unbind(GL_TEXTURE0);
+  glActiveTexture(GL_TEXTURE0);
+  glBindTexture(GL_TEXTURE_2D, 0);
+
   if (mWMSTextureUsed) {
     mWMSTexture.Unbind(GL_TEXTURE1);
 

--- a/plugins/csp-wms-overlays/src/TextureOverlayRenderer.cpp
+++ b/plugins/csp-wms-overlays/src/TextureOverlayRenderer.cpp
@@ -541,7 +541,8 @@ bool TextureOverlayRenderer::Do() {
   mShader.Bind();
 
   // Only bind the enabled textures.
-  mGraphicsEngine->bindCurrentDepthBufferAsTexture(GL_TEXTURE0, false);
+  auto depthbuffer = mGraphicsEngine->getCurrentDepthBufferAsTexture(false);
+  depthbuffer->Bind(GL_TEXTURE0);
   if (mWMSTextureUsed) {
     mWMSTexture.Bind(GL_TEXTURE1);
 
@@ -611,8 +612,7 @@ bool TextureOverlayRenderer::Do() {
   // Dummy draw
   glDrawArrays(GL_POINTS, 0, 1);
 
-  glActiveTexture(GL_TEXTURE0);
-  glBindTexture(GL_TEXTURE_2D, 0);
+  depthbuffer->Unbind(GL_TEXTURE0);
 
   if (mWMSTextureUsed) {
     mWMSTexture.Unbind(GL_TEXTURE1);

--- a/plugins/csp-wms-overlays/src/TextureOverlayRenderer.cpp
+++ b/plugins/csp-wms-overlays/src/TextureOverlayRenderer.cpp
@@ -62,8 +62,7 @@ TextureOverlayRenderer::TextureOverlayRenderer(std::string objectName,
   // create textures ---------------------------------------------------------
   for (auto const& viewport : GetVistaSystem()->GetDisplayManager()->GetViewports()) {
     // Texture for previous renderer depth buffer
-    const auto [buffer, success] =
-        mDepthBufferData.try_emplace(viewport.second, GL_TEXTURE_RECTANGLE);
+    const auto [buffer, success] = mDepthBufferData.try_emplace(viewport.second, GL_TEXTURE_2D);
     if (success) {
       buffer->second.Bind();
       buffer->second.SetWrapS(GL_CLAMP);
@@ -541,8 +540,8 @@ bool TextureOverlayRenderer::Do() {
   VistaTexture& depthBuffer = mDepthBufferData.at(viewport);
 
   depthBuffer.Bind();
-  glCopyTexImage2D(GL_TEXTURE_RECTANGLE, 0, GL_DEPTH_COMPONENT, iViewport[0], iViewport[1],
-      iViewport[2], iViewport[3], 0);
+  glCopyTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT, iViewport[0], iViewport[1], iViewport[2],
+      iViewport[3], 0);
 
   auto object    = mSolarSystem->getObject(mObjectName);
   auto radii     = object->getRadii();

--- a/plugins/csp-wms-overlays/src/TextureOverlayRenderer.hpp
+++ b/plugins/csp-wms-overlays/src/TextureOverlayRenderer.hpp
@@ -43,10 +43,12 @@ namespace csp::wmsoverlays {
 /// do the lookup in the geo-referenced texture. The value is then overlayed on that pixel position.
 class TextureOverlayRenderer : public IVistaOpenGLDraw {
  public:
-  TextureOverlayRenderer(std::string objectName, std::shared_ptr<cs::core::SolarSystem> solarSystem,
-      std::shared_ptr<cs::core::TimeControl> timeControl,
-      std::shared_ptr<cs::core::Settings>    settings,
-      std::shared_ptr<Plugin::Settings>      pluginSettings);
+  TextureOverlayRenderer(std::string            objectName,
+      std::shared_ptr<cs::core::GraphicsEngine> graphicsEngine,
+      std::shared_ptr<cs::core::SolarSystem>    solarSystem,
+      std::shared_ptr<cs::core::TimeControl>    timeControl,
+      std::shared_ptr<cs::core::Settings>       settings,
+      std::shared_ptr<Plugin::Settings>         pluginSettings);
   ~TextureOverlayRenderer() override;
 
   /// Returns the SPICE name of the body to which this renderer is assigned.
@@ -93,10 +95,11 @@ class TextureOverlayRenderer : public IVistaOpenGLDraw {
   /// Synchronously loads a texture for a time-independent map.
   void getTimeIndependentTexture(WebMapTextureLoader::Request const& request);
 
-  std::shared_ptr<cs::core::Settings> mSettings;
-  std::shared_ptr<Plugin::Settings>   mPluginSettings;
-  Plugin::Settings::Body              mSimpleWMSOverlaySettings;
-  std::string                         mObjectName;
+  std::shared_ptr<cs::core::Settings>       mSettings;
+  std::shared_ptr<cs::core::GraphicsEngine> mGraphicsEngine;
+  std::shared_ptr<Plugin::Settings>         mPluginSettings;
+  Plugin::Settings::Body                    mSimpleWMSOverlaySettings;
+  std::string                               mObjectName;
 
   std::unique_ptr<VistaOpenGLNode> mGLNode;
 
@@ -109,9 +112,6 @@ class TextureOverlayRenderer : public IVistaOpenGLDraw {
   static const std::string SURFACE_VERT;
   /// Code for the fragment shader
   static const std::string SURFACE_FRAG;
-
-  /// Store one buffer per viewport
-  std::unordered_map<VistaViewport*, VistaTexture> mDepthBufferData;
 
   /// Stores all textures, for which the request ist still pending.
   std::map<std::string, std::future<std::optional<WebMapTexture>>> mTexturesBuffer;

--- a/src/cs-core/GraphicsEngine.cpp
+++ b/src/cs-core/GraphicsEngine.cpp
@@ -329,76 +329,72 @@ GraphicsEngine::getEclipseShadowMaps() const {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-void GraphicsEngine::bindCurrentDepthBufferAsTexture(int textureUnit, bool forceCopy) {
+VistaTexture* GraphicsEngine::getCurrentDepthBufferAsTexture(bool forceCopy) {
   if (mSettings->mGraphics.pEnableHDR.get()) {
-    mHDRBuffer->getDepthAttachment()->Bind(textureUnit);
-  } else {
-    auto* viewport = GetVistaSystem()->GetDisplayManager()->GetCurrentRenderInfo()->m_pViewport;
-    auto  it       = mDepthBuffers.find(viewport);
-
-    if (it == mDepthBuffers.end()) {
-      ViewportData data;
-      data.mBuffer = std::make_unique<VistaTexture>(GL_TEXTURE_2D);
-      data.mBuffer->Bind();
-      data.mBuffer->SetWrapS(GL_CLAMP);
-      data.mBuffer->SetWrapT(GL_CLAMP);
-      data.mBuffer->SetMinFilter(GL_NEAREST);
-      data.mBuffer->SetMagFilter(GL_NEAREST);
-      data.mBuffer->Unbind();
-
-      mDepthBuffers[viewport] = std::move(data);
-      it                      = mDepthBuffers.find(viewport);
-    }
-
-    if (it->second.mDirty || forceCopy) {
-      it->second.mBuffer->Bind();
-      int x, y, w, h;
-      viewport->GetViewportProperties()->GetPosition(x, y);
-      viewport->GetViewportProperties()->GetSize(w, h);
-      glCopyTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT, x, y, w, h, 0);
-      it->second.mDirty = false;
-      it->second.mBuffer->Unbind();
-    }
-
-    it->second.mBuffer->Bind(textureUnit);
+    return mHDRBuffer->getDepthAttachment();
   }
+
+  auto* viewport = GetVistaSystem()->GetDisplayManager()->GetCurrentRenderInfo()->m_pViewport;
+  auto  it       = mDepthBuffers.find(viewport);
+
+  if (it == mDepthBuffers.end()) {
+    ViewportData data;
+    data.mBuffer = std::make_shared<VistaTexture>(GL_TEXTURE_2D);
+    data.mBuffer->SetWrapS(GL_CLAMP);
+    data.mBuffer->SetWrapT(GL_CLAMP);
+    data.mBuffer->SetMinFilter(GL_NEAREST);
+    data.mBuffer->SetMagFilter(GL_NEAREST);
+
+    mDepthBuffers[viewport] = std::move(data);
+    it                      = mDepthBuffers.find(viewport);
+  }
+
+  if (it->second.mDirty || forceCopy) {
+    int x, y, w, h;
+    viewport->GetViewportProperties()->GetPosition(x, y);
+    viewport->GetViewportProperties()->GetSize(w, h);
+    it->second.mBuffer->Bind();
+    glCopyTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT, x, y, w, h, 0);
+    it->second.mBuffer->Unbind();
+    it->second.mDirty = false;
+  }
+
+  return it->second.mBuffer.get();
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-void GraphicsEngine::bindCurrentColorBufferAsTexture(int textureUnit, bool forceCopy) {
+VistaTexture* GraphicsEngine::getCurrentColorBufferAsTexture(bool forceCopy) {
   if (mSettings->mGraphics.pEnableHDR.get()) {
-    mHDRBuffer->getCurrentReadAttachment()->Bind(textureUnit);
-  } else {
-    auto* viewport = GetVistaSystem()->GetDisplayManager()->GetCurrentRenderInfo()->m_pViewport;
-    auto  it       = mColorBuffers.find(viewport);
-
-    if (it == mColorBuffers.end()) {
-      ViewportData data;
-      data.mBuffer = std::make_unique<VistaTexture>(GL_TEXTURE_2D);
-      data.mBuffer->Bind();
-      data.mBuffer->SetWrapS(GL_CLAMP);
-      data.mBuffer->SetWrapT(GL_CLAMP);
-      data.mBuffer->SetMinFilter(GL_NEAREST);
-      data.mBuffer->SetMagFilter(GL_NEAREST);
-      data.mBuffer->Unbind();
-
-      mColorBuffers[viewport] = std::move(data);
-      it                      = mColorBuffers.find(viewport);
-    }
-
-    if (it->second.mDirty || forceCopy) {
-      it->second.mBuffer->Bind();
-      int x, y, w, h;
-      viewport->GetViewportProperties()->GetPosition(x, y);
-      viewport->GetViewportProperties()->GetSize(w, h);
-      glCopyTexImage2D(GL_TEXTURE_2D, 0, GL_RGB8, x, y, w, h, 0);
-      it->second.mDirty = false;
-      it->second.mBuffer->Unbind();
-    }
-
-    it->second.mBuffer->Bind(textureUnit);
+    return mHDRBuffer->getCurrentReadAttachment();
   }
+
+  auto* viewport = GetVistaSystem()->GetDisplayManager()->GetCurrentRenderInfo()->m_pViewport;
+  auto  it       = mColorBuffers.find(viewport);
+
+  if (it == mColorBuffers.end()) {
+    ViewportData data;
+    data.mBuffer = std::make_shared<VistaTexture>(GL_TEXTURE_2D);
+    data.mBuffer->SetWrapS(GL_CLAMP);
+    data.mBuffer->SetWrapT(GL_CLAMP);
+    data.mBuffer->SetMinFilter(GL_NEAREST);
+    data.mBuffer->SetMagFilter(GL_NEAREST);
+
+    mColorBuffers[viewport] = std::move(data);
+    it                      = mColorBuffers.find(viewport);
+  }
+
+  if (it->second.mDirty || forceCopy) {
+    int x, y, w, h;
+    viewport->GetViewportProperties()->GetPosition(x, y);
+    viewport->GetViewportProperties()->GetSize(w, h);
+    it->second.mBuffer->Bind();
+    glCopyTexImage2D(GL_TEXTURE_2D, 0, GL_RGB8, x, y, w, h, 0);
+    it->second.mBuffer->Unbind();
+    it->second.mDirty = false;
+  }
+
+  return it->second.mBuffer.get();
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/cs-core/GraphicsEngine.cpp
+++ b/src/cs-core/GraphicsEngine.cpp
@@ -298,6 +298,14 @@ void GraphicsEngine::update(glm::vec3 const& sunDirection) {
     pAverageLuminance = mToneMappingNode->getLastAverageLuminance();
     pMaximumLuminance = mToneMappingNode->getLastMaximumLuminance();
   }
+
+  for (auto& viewport : mDepthBuffers) {
+    viewport.second.mDirty = true;
+  }
+
+  for (auto& viewport : mColorBuffers) {
+    viewport.second.mDirty = true;
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -317,6 +325,80 @@ std::shared_ptr<graphics::HDRBuffer> GraphicsEngine::getHDRBuffer() const {
 std::vector<std::shared_ptr<graphics::EclipseShadowMap>> const&
 GraphicsEngine::getEclipseShadowMaps() const {
   return mEclipseShadowMaps;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+void GraphicsEngine::bindCurrentDepthBufferAsTexture(int textureUnit, bool forceCopy) {
+  if (mSettings->mGraphics.pEnableHDR.get()) {
+    mHDRBuffer->getDepthAttachment()->Bind(textureUnit);
+  } else {
+    auto* viewport = GetVistaSystem()->GetDisplayManager()->GetCurrentRenderInfo()->m_pViewport;
+    auto  it       = mDepthBuffers.find(viewport);
+
+    if (it == mDepthBuffers.end()) {
+      ViewportData data;
+      data.mBuffer = std::make_unique<VistaTexture>(GL_TEXTURE_2D);
+      data.mBuffer->Bind();
+      data.mBuffer->SetWrapS(GL_CLAMP);
+      data.mBuffer->SetWrapT(GL_CLAMP);
+      data.mBuffer->SetMinFilter(GL_NEAREST);
+      data.mBuffer->SetMagFilter(GL_NEAREST);
+      data.mBuffer->Unbind();
+
+      mDepthBuffers[viewport] = std::move(data);
+      it                      = mDepthBuffers.find(viewport);
+    }
+
+    if (it->second.mDirty || forceCopy) {
+      it->second.mBuffer->Bind();
+      int x, y, w, h;
+      viewport->GetViewportProperties()->GetPosition(x, y);
+      viewport->GetViewportProperties()->GetSize(w, h);
+      glCopyTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT, x, y, w, h, 0);
+      it->second.mDirty = false;
+      it->second.mBuffer->Unbind();
+    }
+
+    it->second.mBuffer->Bind(textureUnit);
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+void GraphicsEngine::bindCurrentColorBufferAsTexture(int textureUnit, bool forceCopy) {
+  if (mSettings->mGraphics.pEnableHDR.get()) {
+    mHDRBuffer->getCurrentReadAttachment()->Bind(textureUnit);
+  } else {
+    auto* viewport = GetVistaSystem()->GetDisplayManager()->GetCurrentRenderInfo()->m_pViewport;
+    auto  it       = mColorBuffers.find(viewport);
+
+    if (it == mColorBuffers.end()) {
+      ViewportData data;
+      data.mBuffer = std::make_unique<VistaTexture>(GL_TEXTURE_2D);
+      data.mBuffer->Bind();
+      data.mBuffer->SetWrapS(GL_CLAMP);
+      data.mBuffer->SetWrapT(GL_CLAMP);
+      data.mBuffer->SetMinFilter(GL_NEAREST);
+      data.mBuffer->SetMagFilter(GL_NEAREST);
+      data.mBuffer->Unbind();
+
+      mColorBuffers[viewport] = std::move(data);
+      it                      = mColorBuffers.find(viewport);
+    }
+
+    if (it->second.mDirty || forceCopy) {
+      it->second.mBuffer->Bind();
+      int x, y, w, h;
+      viewport->GetViewportProperties()->GetPosition(x, y);
+      viewport->GetViewportProperties()->GetSize(w, h);
+      glCopyTexImage2D(GL_TEXTURE_2D, 0, GL_RGB8, x, y, w, h, 0);
+      it->second.mDirty = false;
+      it->second.mBuffer->Unbind();
+    }
+
+    it->second.mBuffer->Bind(textureUnit);
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/cs-core/GraphicsEngine.hpp
+++ b/src/cs-core/GraphicsEngine.hpp
@@ -59,6 +59,14 @@ class CS_CORE_EXPORT GraphicsEngine {
   /// SolarSystem to get all relevant eclipse shadow maps for a given position in space.
   std::vector<std::shared_ptr<graphics::EclipseShadowMap>> const& getEclipseShadowMaps() const;
 
+  /// Binds the current depth or color buffer as a texture to the given texture unit. If HDR
+  /// rendering is enabled, the current read-targets are used. If HDR rendering is disabled, the
+  /// frame buffer contents are copied to a texture first. This copy is only done once per frame,
+  /// subsequent calls will use the cached texture. If you set forceCopy to true, the texture will
+  /// be copied again.
+  void bindCurrentDepthBufferAsTexture(int textureUnit, bool forceCopy);
+  void bindCurrentColorBufferAsTexture(int textureUnit, bool forceCopy);
+
  private:
   void calculateCascades();
 
@@ -70,6 +78,17 @@ class CS_CORE_EXPORT GraphicsEngine {
   std::shared_ptr<graphics::ToneMappingNode>               mToneMappingNode;
   std::vector<std::shared_ptr<graphics::EclipseShadowMap>> mEclipseShadowMaps;
   std::shared_ptr<VistaTexture>                            mFallbackEclipseShadowMap;
+
+  struct ViewportData {
+    std::unique_ptr<VistaTexture> mBuffer;
+    bool                          mDirty = true;
+  };
+
+  // These are used to cache the frame buffer contents for the current viewport for the
+  // bindCurrentDepthBufferAsTexture and bindCurrentColorBufferAsTexture calls. They are only
+  // filled if the methods are called and HDR rendering is disabled.
+  std::unordered_map<VistaViewport*, ViewportData> mDepthBuffers;
+  std::unordered_map<VistaViewport*, ViewportData> mColorBuffers;
 };
 
 } // namespace cs::core

--- a/src/cs-core/GraphicsEngine.hpp
+++ b/src/cs-core/GraphicsEngine.hpp
@@ -80,7 +80,9 @@ class CS_CORE_EXPORT GraphicsEngine {
   std::shared_ptr<VistaTexture>                            mFallbackEclipseShadowMap;
 
   struct ViewportData {
-    std::unique_ptr<VistaTexture> mBuffer;
+    // MSVC does not like a unique_ptr here. Let's use a shared_ptr instead, although it is not
+    // really shared.
+    std::shared_ptr<VistaTexture> mBuffer;
     bool                          mDirty = true;
   };
 

--- a/src/cs-core/GraphicsEngine.hpp
+++ b/src/cs-core/GraphicsEngine.hpp
@@ -59,13 +59,13 @@ class CS_CORE_EXPORT GraphicsEngine {
   /// SolarSystem to get all relevant eclipse shadow maps for a given position in space.
   std::vector<std::shared_ptr<graphics::EclipseShadowMap>> const& getEclipseShadowMaps() const;
 
-  /// Binds the current depth or color buffer as a texture to the given texture unit. If HDR
-  /// rendering is enabled, the current read-targets are used. If HDR rendering is disabled, the
-  /// frame buffer contents are copied to a texture first. This copy is only done once per frame,
-  /// subsequent calls will use the cached texture. If you set forceCopy to true, the texture will
-  /// be copied again.
-  void bindCurrentDepthBufferAsTexture(int textureUnit, bool forceCopy);
-  void bindCurrentColorBufferAsTexture(int textureUnit, bool forceCopy);
+  /// Returns the current depth or color buffer as a texture which can be used as shader input.
+  /// If HDR rendering is enabled, this simply returns the current read-targets. If HDR rendering is
+  /// disabled, the current frame buffer contents are copied to a texture first. This copy is only
+  /// done once per frame, subsequent calls will use the cached texture. If you set forceCopy to
+  /// true, the texture will be copied again.
+  VistaTexture* getCurrentDepthBufferAsTexture(bool forceCopy);
+  VistaTexture* getCurrentColorBufferAsTexture(bool forceCopy);
 
  private:
   void calculateCascades();
@@ -87,7 +87,7 @@ class CS_CORE_EXPORT GraphicsEngine {
   };
 
   // These are used to cache the frame buffer contents for the current viewport for the
-  // bindCurrentDepthBufferAsTexture and bindCurrentColorBufferAsTexture calls. They are only
+  // getCurrentDepthBufferAsTexture and getCurrentColorBufferAsTexture calls. They are only
   // filled if the methods are called and HDR rendering is disabled.
   std::unordered_map<VistaViewport*, ViewportData> mDepthBuffers;
   std::unordered_map<VistaViewport*, ViewportData> mColorBuffers;

--- a/src/cs-core/GraphicsEngine.hpp
+++ b/src/cs-core/GraphicsEngine.hpp
@@ -5,8 +5,8 @@
 // SPDX-FileCopyrightText: German Aerospace Center (DLR) <cosmoscout@dlr.de>
 // SPDX-License-Identifier: MIT
 
-#ifndef CS_CORE_GRAPHICS_GraphicsEngine_HPP
-#define CS_CORE_GRAPHICS_GraphicsEngine_HPP
+#ifndef CS_CORE_GRAPHICS_ENGINE_HPP
+#define CS_CORE_GRAPHICS_ENGINE_HPP
 
 #include "../cs-graphics/HDRBuffer.hpp"
 #include "../cs-graphics/Shadows.hpp"
@@ -93,4 +93,4 @@ class CS_CORE_EXPORT GraphicsEngine {
 
 } // namespace cs::core
 
-#endif // CS_CORE_GRAPHICS_GraphicsEngine_HPP
+#endif // CS_CORE_GRAPHICS_ENGINE_HPP


### PR DESCRIPTION
The number of times we copied the depth buffer per frame has increased quite significantly. Once per atmosphere, once per sharad profile, once per WMS overlay. Soon I want to render some decals which will also require access to the depth buffer.

This PR adds a method to the `GraphicsEngine` which allows binding the current depth and color targets of the framebuffer as textures.

I have tested this with multiple viewports, but not in stereo.