### PR TITLE
Feature/lod bodies skip white tiles

### DIFF
--- a/plugins/csp-lod-bodies/src/TileSourceWebMapService.cpp
+++ b/plugins/csp-lod-bodies/src/TileSourceWebMapService.cpp
@@ -418,10 +418,8 @@ std::optional<std::string> TileSourceWebMapService::loadData(TileId const& tileI
   if (boost::filesystem::exists(cacheFilePath) &&
       boost::filesystem::file_size(cacheFile.str()) < 2000) {
     boost::filesystem::remove(cacheFilePath);
-    if (format == "pngRGB") {
-      logger().debug("Tile (Level: {}, x: {}, y: {}):", tileId.level(), x, y);
-      logger().debug(url.str());
-    }
+    logger().debug("Failed to download tile data: File '{}' is too small and thus seems to be invalid.", cacheFile.str());
+    logger().debug(url.str());
     return std::nullopt;
   }
 

--- a/plugins/csp-lod-bodies/src/TileSourceWebMapService.cpp
+++ b/plugins/csp-lod-bodies/src/TileSourceWebMapService.cpp
@@ -139,8 +139,8 @@ bool loadImpl(TileSourceWebMapService* source, BaseTileData* tile, TileId const&
     bool isCompletelyWhiteTile = true;
     // Iterate through pixel values and stop after one non-white pixel in tile
     for (int i = 0; i < width * height; ++i) {
-      unsigned char* pixel = (unsigned char*)data + i * 4;
-      if (!(pixel[0] == 255 && pixel[1] == 255 && pixel[2] == 255 && pixel[3] == 255)) {
+      auto pixel = reinterpret_cast<uint8_t*>(data) + i * 4;
+      if (pixel[0] != 255 || pixel[1] != 255 || pixel[2] != 255 || pixel[3] != 255) {
         isCompletelyWhiteTile = false;
         break;
       }
@@ -526,7 +526,10 @@ bool TileSourceWebMapService::isSame(TileSource const* other) const {
   return casted != nullptr && mUrl == casted->mUrl && mCache == casted->mCache &&
          mLayers == casted->mLayers && mFormat == casted->mFormat;
 }
-void TileSourceWebMapService::markTileDataAsInvalid(const boost::filesystem::path& TileDataPath) {
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+void TileSourceWebMapService::markTileDataAsInvalid(boost::filesystem::path const& TileDataPath) {
   m_LastTimeTileFailed[TileDataPath] = std::chrono::system_clock::now();
 }
 

--- a/plugins/csp-lod-bodies/src/TileSourceWebMapService.cpp
+++ b/plugins/csp-lod-bodies/src/TileSourceWebMapService.cpp
@@ -136,8 +136,8 @@ bool loadImpl(TileSourceWebMapService* source, BaseTileData* tile, TileId const&
       return false;
     }
 
-    bool isCompletelyWhiteTile    = true;
-    //Iterate through pixel values and stop after one non-white pixel in tile
+    bool isCompletelyWhiteTile = true;
+    // Iterate through pixel values and stop after one non-white pixel in tile
     for (int i = 0; i < width * height; ++i) {
       unsigned char* pixel = (unsigned char*)data + i * 4;
       if (!(pixel[0] == 255 && pixel[1] == 255 && pixel[2] == 255 && pixel[3] == 255)) {
@@ -412,18 +412,18 @@ std::optional<std::string> TileSourceWebMapService::loadData(TileId const& tileI
           "Failed to download tile data: Cannot open '{}' for writing!", cacheFile.str()));
     }
 
-    //Check if we already had an error with this tile cache file in the past
-    if (m_LastTimeTileFailed.find(cacheFilePath) != m_LastTimeTileFailed.end())
-    {
+    // Check if we already had an error with this tile cache file in the past
+    if (m_LastTimeTileFailed.find(cacheFilePath) != m_LastTimeTileFailed.end()) {
       auto cooldownTime = std::chrono::seconds(3);
-      auto timeNow       = std::chrono::system_clock::now();
-      if (timeNow - m_LastTimeTileFailed[cacheFilePath]< cooldownTime) {
+      auto timeNow      = std::chrono::system_clock::now();
+      if (timeNow - m_LastTimeTileFailed[cacheFilePath] < cooldownTime) {
         logger().warn(
-              "Failed to download tile data: Waiting for '{}' to cool down", cacheFile.str());
-          //Sleep for the rest of the cooldown time (plus a little longer 500ms)
-          std::this_thread::sleep_until(m_LastTimeTileFailed[cacheFilePath] + cooldownTime + std::chrono::milliseconds(500));
-        }
-        m_LastTimeTileFailed.erase(cacheFilePath);  
+            "Failed to download tile data: Waiting for '{}' to cool down", cacheFile.str());
+        // Sleep for the rest of the cooldown time (plus a little longer 500ms)
+        std::this_thread::sleep_until(
+            m_LastTimeTileFailed[cacheFilePath] + cooldownTime + std::chrono::milliseconds(500));
+      }
+      m_LastTimeTileFailed.erase(cacheFilePath);
     }
 
     curlpp::Easy request;
@@ -526,8 +526,7 @@ bool TileSourceWebMapService::isSame(TileSource const* other) const {
   return casted != nullptr && mUrl == casted->mUrl && mCache == casted->mCache &&
          mLayers == casted->mLayers && mFormat == casted->mFormat;
 }
-void TileSourceWebMapService::markTileDataAsInvalid(const boost::filesystem::path& TileDataPath)
-{
+void TileSourceWebMapService::markTileDataAsInvalid(const boost::filesystem::path& TileDataPath) {
   m_LastTimeTileFailed[TileDataPath] = std::chrono::system_clock::now();
 }
 

--- a/plugins/csp-lod-bodies/src/TileSourceWebMapService.cpp
+++ b/plugins/csp-lod-bodies/src/TileSourceWebMapService.cpp
@@ -413,17 +413,17 @@ std::optional<std::string> TileSourceWebMapService::loadData(TileId const& tileI
     }
 
     // Check if we already had an error with this tile cache file in the past
-    if (m_LastTimeTileFailed.find(cacheFilePath) != m_LastTimeTileFailed.end()) {
+    if (mLastTimeTileFailed.find(cacheFilePath) != mLastTimeTileFailed.end()) {
       auto cooldownTime = std::chrono::seconds(3);
       auto timeNow      = std::chrono::system_clock::now();
-      if (timeNow - m_LastTimeTileFailed[cacheFilePath] < cooldownTime) {
+      if (timeNow - mLastTimeTileFailed[cacheFilePath] < cooldownTime) {
         logger().warn(
             "Failed to download tile data: Waiting for '{}' to cool down", cacheFile.str());
         // Sleep for the rest of the cooldown time (plus a little longer 500ms)
         std::this_thread::sleep_until(
-            m_LastTimeTileFailed[cacheFilePath] + cooldownTime + std::chrono::milliseconds(500));
+            mLastTimeTileFailed[cacheFilePath] + cooldownTime + std::chrono::milliseconds(500));
       }
-      m_LastTimeTileFailed.erase(cacheFilePath);
+      mLastTimeTileFailed.erase(cacheFilePath);
     }
 
     curlpp::Easy request;
@@ -530,7 +530,7 @@ bool TileSourceWebMapService::isSame(TileSource const* other) const {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 void TileSourceWebMapService::markTileDataAsInvalid(boost::filesystem::path const& TileDataPath) {
-  m_LastTimeTileFailed[TileDataPath] = std::chrono::system_clock::now();
+  mLastTimeTileFailed[TileDataPath] = std::chrono::system_clock::now();
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/plugins/csp-lod-bodies/src/TileSourceWebMapService.cpp
+++ b/plugins/csp-lod-bodies/src/TileSourceWebMapService.cpp
@@ -371,7 +371,7 @@ std::optional<std::string> TileSourceWebMapService::loadData(TileId const& tileI
 
   // The file is already there, we can return it.
   if (boost::filesystem::exists(cacheFilePath) &&
-      boost::filesystem::file_size(cacheFile.str()) > 2000) {
+      boost::filesystem::file_size(cacheFile.str()) > 0) {
     return cacheFile.str();
   }
 

--- a/plugins/csp-lod-bodies/src/TileSourceWebMapService.cpp
+++ b/plugins/csp-lod-bodies/src/TileSourceWebMapService.cpp
@@ -351,7 +351,7 @@ std::optional<std::string> TileSourceWebMapService::loadData(TileId const& tileI
 
   // The file is already there, we can return it.
   if (boost::filesystem::exists(cacheFilePath) &&
-      boost::filesystem::file_size(cacheFile.str()) > 0) {
+      boost::filesystem::file_size(cacheFile.str()) > 2000) {
     return cacheFile.str();
   }
 
@@ -412,6 +412,17 @@ std::optional<std::string> TileSourceWebMapService::loadData(TileId const& tileI
 
     std::remove(cacheFile.str().c_str());
     throw std::runtime_error(sstr.str());
+  }
+
+  // The file is there but obviously corrupt. Remove it.
+  if (boost::filesystem::exists(cacheFilePath) &&
+      boost::filesystem::file_size(cacheFile.str()) < 2000) {
+    boost::filesystem::remove(cacheFilePath);
+    if (format == "pngRGB") {
+      logger().debug("Tile (Level: {}, x: {}, y: {}):", tileId.level(), x, y);
+      logger().debug(url.str());
+    }
+    return std::nullopt;
   }
 
   boost::filesystem::perms filePerms =

--- a/plugins/csp-lod-bodies/src/TileSourceWebMapService.hpp
+++ b/plugins/csp-lod-bodies/src/TileSourceWebMapService.hpp
@@ -70,10 +70,10 @@ class TileSourceWebMapService : public TileSource {
   // writable) a std::runtime_error is thrown.
   std::optional<std::string> loadData(TileId const& tileId, int x, int y);
 
-
-  // This will mark a previously downloaded tile file as invalid together with the current timestamp.
-  // This information is used to avoid quering the same tile immediately after we've received invalid data from server
-  // Tracking the time of the last error allows us to apply a kind of cooldown mechanism
+  // This will mark a previously downloaded tile file as invalid together with the current
+  // timestamp. This information is used to avoid quering the same tile immediately after we've
+  // received invalid data from server Tracking the time of the last error allows us to apply a kind
+  // of cooldown mechanism
   void markTileDataAsInvalid(const boost::filesystem::path& TileDataPath);
 
  private:
@@ -86,8 +86,8 @@ class TileSourceWebMapService : public TileSource {
   TileDataType          mFormat = TileDataType::eColor;
   uint32_t              mResolution;
 
-  //We keep track of the time a tile has had invalid data from the server.
-  //This timestamp is used for a cooldown mechanism
+  // We keep track of the time a tile has had invalid data from the server.
+  // This timestamp is used for a cooldown mechanism
   std::map<boost::filesystem::path, std::chrono::system_clock::time_point> m_LastTimeTileFailed;
 };
 } // namespace csp::lodbodies

--- a/plugins/csp-lod-bodies/src/TileSourceWebMapService.hpp
+++ b/plugins/csp-lod-bodies/src/TileSourceWebMapService.hpp
@@ -74,7 +74,7 @@ class TileSourceWebMapService : public TileSource {
   // timestamp. This information is used to avoid quering the same tile immediately after we've
   // received invalid data from server Tracking the time of the last error allows us to apply a kind
   // of cooldown mechanism
-  void markTileDataAsInvalid(const boost::filesystem::path& TileDataPath);
+  void markTileDataAsInvalid(boost::filesystem::path const& TileDataPath);
 
  private:
   static std::mutex mFileSystemMutex;
@@ -88,7 +88,7 @@ class TileSourceWebMapService : public TileSource {
 
   // We keep track of the time a tile has had invalid data from the server.
   // This timestamp is used for a cooldown mechanism
-  std::map<boost::filesystem::path, std::chrono::system_clock::time_point> m_LastTimeTileFailed;
+  std::map<boost::filesystem::path, std::chrono::system_clock::time_point> mLastTimeTileFailed;
 };
 } // namespace csp::lodbodies
 

--- a/plugins/csp-lod-bodies/src/TileSourceWebMapService.hpp
+++ b/plugins/csp-lod-bodies/src/TileSourceWebMapService.hpp
@@ -15,6 +15,7 @@
 #include <cstdio>
 #include <optional>
 #include <string>
+#include <chrono>
 
 namespace csp::lodbodies {
 

--- a/plugins/csp-lod-bodies/src/TileSourceWebMapService.hpp
+++ b/plugins/csp-lod-bodies/src/TileSourceWebMapService.hpp
@@ -12,10 +12,10 @@
 #include "TileData.hpp"
 #include "TileSource.hpp"
 
+#include <chrono>
 #include <cstdio>
 #include <optional>
 #include <string>
-#include <chrono>
 
 namespace csp::lodbodies {
 

--- a/plugins/csp-lod-bodies/src/TileSourceWebMapService.hpp
+++ b/plugins/csp-lod-bodies/src/TileSourceWebMapService.hpp
@@ -70,6 +70,12 @@ class TileSourceWebMapService : public TileSource {
   // writable) a std::runtime_error is thrown.
   std::optional<std::string> loadData(TileId const& tileId, int x, int y);
 
+
+  // This will mark a previously downloaded tile file as invalid together with the current timestamp.
+  // This information is used to avoid quering the same tile immediately after we've received invalid data from server
+  // Tracking the time of the last error allows us to apply a kind of cooldown mechanism
+  void markTileDataAsInvalid(const boost::filesystem::path& TileDataPath);
+
  private:
   static std::mutex mFileSystemMutex;
 
@@ -79,6 +85,10 @@ class TileSourceWebMapService : public TileSource {
   std::string           mLayers;
   TileDataType          mFormat = TileDataType::eColor;
   uint32_t              mResolution;
+
+  //We keep track of the time a tile has had invalid data from the server.
+  //This timestamp is used for a cooldown mechanism
+  std::map<boost::filesystem::path, std::chrono::system_clock::time_point> m_LastTimeTileFailed;
 };
 } // namespace csp::lodbodies
 


### PR DESCRIPTION
This pull request refers to the following issue: #417

Major changes are:
[x] After loading a WMS Color tile, check if it completly white, if so remove the file from cache and mark tile data as invalid
[x] Before requesting new WMS tile data from server, check if the same tile already was marked invalid recently (cooldown time)
[x] Wait for cooldown time before requesting tile from server