### PR TITLE
:beetle: Fix bug with atmosphere problems on one eye.

### DIFF
--- a/plugins/csp-atmospheres/src/Atmosphere.cpp
+++ b/plugins/csp-atmospheres/src/Atmosphere.cpp
@@ -375,8 +375,8 @@ bool Atmosphere::Do() {
     mHDRBuffer->bind();
   }
 
-  auto depthBuffer = mGraphicsEngine->getCurrentDepthBufferAsTexture(false);
-  auto colorBuffer = mGraphicsEngine->getCurrentColorBufferAsTexture(false);
+  auto depthBuffer = mGraphicsEngine->getCurrentDepthBufferAsTexture(true);
+  auto colorBuffer = mGraphicsEngine->getCurrentColorBufferAsTexture(true);
   depthBuffer->Bind(GL_TEXTURE0);
   colorBuffer->Bind(GL_TEXTURE1);
 

--- a/src/cs-core/GraphicsEngine.cpp
+++ b/src/cs-core/GraphicsEngine.cpp
@@ -298,14 +298,6 @@ void GraphicsEngine::update(glm::vec3 const& sunDirection) {
     pAverageLuminance = mToneMappingNode->getLastAverageLuminance();
     pMaximumLuminance = mToneMappingNode->getLastMaximumLuminance();
   }
-
-  for (auto& viewport : mDepthBuffers) {
-    viewport.second.mDirty = true;
-  }
-
-  for (auto& viewport : mColorBuffers) {
-    viewport.second.mDirty = true;
-  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fix bug from issue #420 with atmosphere not rendering properly on one eye. This happened after #407 introduced the bug. The reason is that before #407 the depth and color buffers were copied on each Do(). Since #407 the copying through "mDirty = true" does not have the wished for effect. Now the "forceCopy" parameter is set to true and used to ensure copying properly.