### PR TITLE
Fix CosmoScout atmosphere model

### DIFF
--- a/plugins/csp-atmospheres/src/models/cosmoscout/Model.cpp
+++ b/plugins/csp-atmospheres/src/models/cosmoscout/Model.cpp
@@ -53,7 +53,7 @@ bool Model::init(
   mShader.Destroy();
 
   auto sFrag = cs::utils::filesystem::loadToString(
-      "../share/resources/shaders/atmospheres-models/cosmoscout/model.glsl");
+      "../share/resources/shaders/atmosphere-models/cosmoscout/model.glsl");
 
   cs::utils::replaceString(sFrag, "ATMO_RADIUS", cs::utils::toString(atmosphereRadius));
   cs::utils::replaceString(sFrag, "PLANET_RADIUS", cs::utils::toString(planetRadius));


### PR DESCRIPTION
When loading the CosmoScoutVR atmosphere model a "string too long" exception was thrown. This fixes the error, as there was a typo in the loading logic.

This PR still needs work, as the atmosphere now renders only black.