### PR TITLE
:beetle: Persist buffer object ids to prevent premature deletion

### DIFF
--- a/src/cs-graphics/internal/gltfmodel.cpp
+++ b/src/cs-graphics/internal/gltfmodel.cpp
@@ -1154,6 +1154,13 @@ Primitive GltfShared::createMeshPrimitive(
     }
   }
 
+  // At this point, bufferMap contains the only reference to the OpenGL object ids
+  // for the newly created buffer objects, so unless we persist those in some way,
+  // the buffer memory may be cleared by the graphics driver.
+  for (auto const& bufferEntry : bufferMap) {
+    myPrimitive.bufferPtrs.push_back(bufferEntry.second.id);
+  }
+
   CheckGLErrors("createMeshPrimitive");
   return myPrimitive;
 }

--- a/src/cs-graphics/internal/gltfmodel.hpp
+++ b/src/cs-graphics/internal/gltfmodel.hpp
@@ -121,6 +121,7 @@ struct Primitive {
   glm::vec3 emissiveFactor{};
 
   std::vector<std::pair<Texture, TextureVar>> textures;
+  std::vector<std::shared_ptr<unsigned int>>  bufferPtrs;
   std::shared_ptr<unsigned int>               vaoPtr;
   std::shared_ptr<unsigned int>               programPtr;
 };


### PR DESCRIPTION
On a system running a RTX Pro 5000, the GLTF renderer encounters various issues when trying to display even a basic cube model.
This ranges from rendering only parts of a more complex model, over rendering seemingly nothing at all, to crashing as soon as the model gets into frame.

When investigating the issue, I found that the `shared_ptr`s responsible for managing and deleting data buffers of a `Primitive` go out of scope when the creation of the Primitive is finished and not when the `Primitive` itself goes out of scope.
This means, that all buffers belonging to `Primitive`s are in an undefined state, so it is kind of surprising that this worked on all other PCs so far.

This PR fixes this by simply storing a list of all allocated buffers as a member of `Primitive` objects.